### PR TITLE
fix(logging): resolve relative LOG_FILE_PATH against project root

### DIFF
--- a/src/moneyforward_pk/utils/logging_config.py
+++ b/src/moneyforward_pk/utils/logging_config.py
@@ -43,9 +43,12 @@ def setup_common_logging(
         else os.environ.get("LOG_FILE_ENABLED", "false").lower() == "true"
     )
     if enabled:
-        path = Path(
-            log_file_path or os.environ.get("LOG_FILE_PATH", "moneyforward_pk.log")
-        )
+        raw = log_file_path or os.environ.get("LOG_FILE_PATH", "moneyforward_pk.log")
+        path = Path(raw)
+        if not path.is_absolute():
+            # Resolve against project root (src/moneyforward_pk/utils/ → 3 levels up)
+            project_root = Path(__file__).resolve().parents[3]
+            path = project_root / path
         path.parent.mkdir(parents=True, exist_ok=True)
         fh = TimedRotatingFileHandler(
             path, when="midnight", backupCount=14, encoding="utf-8"


### PR DESCRIPTION
## Summary

- `logging_config.py` が `LOG_FILE_PATH` env var の相対パスを CWD 基準で解決していたバグを修正
- scrapy 実行時 CWD = `src/` のため `src/runtime/logs/` にログが生成されていた
- 相対パスを `Path(__file__).resolve().parents[3]` (project root) 基準に解決するよう変更

## Root Cause

`.env` の `LOG_FILE_PATH=runtime/logs/moneyforward_pk.log` (相対パス) を `logging_config.py` が直読みし、`Path()` に渡すだけで絶対パス化しなかった。`settings.py` の `_resolve_project_path` は通らないため。

## Test plan

- [x] `ruff check` clean
- [x] `pytest tests/` 239 passed

closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)