### PR TITLE
fix(reports): _loader.py を新出力形式 JSON 配列対応に更新 (Issue #41)

### DIFF
--- a/.workbench/alias_rules
+++ b/.workbench/alias_rules
@@ -18,3 +18,7 @@ crawl-trans   cd $PROJECT_ROOT ; cmd.exe /c wsl_runner.bat transaction @args  # 
 crawl-asset   cd $PROJECT_ROOT ; cmd.exe /c wsl_runner.bat asset @args  # WSL 経由で asset_allocation のみ実行
 crawl-acct    cd $PROJECT_ROOT ; cmd.exe /c wsl_runner.bat account @args  # WSL 経由で account のみ実行
 wslrun        cd $PROJECT_ROOT ; cmd.exe /c wsl_runner.bat @args  # WSL 経由で job_runner.sh を実行
+
+report-bal    cd $PROJECT_ROOT/src ; $VENV_PYTHON -m moneyforward_pk.reports --input-dir ../runtime/output balances @args  # 月次収支レポート (--year YYYY --month M)
+report-asset  cd $PROJECT_ROOT/src ; $VENV_PYTHON -m moneyforward_pk.reports --input-dir ../runtime/output asset_allocation @args  # 資産配分レポート (--year YYYY --month M --day D)
+report-csv    cd $PROJECT_ROOT/src ; $VENV_PYTHON -m moneyforward_pk.reports --input-dir ../runtime/output balances_csv @args  # 年次CSV出力 (--year YYYY --output PATH)

--- a/src/moneyforward_pk/reports/_loader.py
+++ b/src/moneyforward_pk/reports/_loader.py
@@ -1,7 +1,7 @@
-"""JSONL 読み込みユーティリティ (純関数).
+"""出力 JSON 読み込みユーティリティ (純関数).
 
-JsonOutputPipeline が書き出した ``{spider}_{date:%Y%m%d}.jsonl`` を
-glob で探索し、フィルタ条件で要素を絞り込む。
+crawl_runner が書き出した ``moneyforward_{spider_type}.json`` (JSON 配列) を
+読み込み、フィルタ条件で要素を絞り込む。
 """
 
 from __future__ import annotations
@@ -37,38 +37,30 @@ def iter_jsonl(path: Path) -> Iterator[dict]:
             yield json.loads(stripped)
 
 
-def load_spider_jsonl(
+def load_output_json(
     output_dir: Path,
-    spider_prefix: str,
+    spider_type: str,
 ) -> Iterator[dict]:
-    """``output_dir`` 配下の ``{spider_prefix}_*.jsonl`` を全件読み出す.
+    """``output_dir/moneyforward_{spider_type}.json`` を全件読み出す.
 
     Parameters
     ----------
     output_dir : Path
-        JsonOutputPipeline の出力ディレクトリ。
-    spider_prefix : str
-        ファイル名 prefix (例: ``mf_transaction``)。サニタイズ済みを想定。
+        crawl_runner の出力ディレクトリ。
+    spider_type : str
+        spider 種別 (例: ``transaction``, ``asset_allocation``)。
 
     Yields
     ------
     dict
-        各 JSONL 行。複数ファイルが存在する場合は ``mtime`` 昇順で結合。
+        JSON 配列の各要素。ファイルが存在しない場合は空イテレータ。
     """
-    if not output_dir.exists():
+    path = output_dir / f"moneyforward_{spider_type}.json"
+    if not path.exists():
         return
-    files = sorted(
-        (
-            p
-            for p in output_dir.iterdir()
-            if p.is_file()
-            and p.name.startswith(f"{spider_prefix}_")
-            and p.suffix == ".jsonl"
-        ),
-        key=lambda p: p.stat().st_mtime,
-    )
-    for f in files:
-        yield from iter_jsonl(f)
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    yield from data
 
 
 def filter_year_month(items: Iterable[dict], year: int, month: int) -> Iterator[dict]:

--- a/src/moneyforward_pk/reports/cli.py
+++ b/src/moneyforward_pk/reports/cli.py
@@ -21,7 +21,7 @@ from moneyforward_pk.reports import balances as bal_mod
 from moneyforward_pk.reports._loader import (
     filter_year_month,
     filter_year_month_day,
-    load_spider_jsonl,
+    load_output_json,
 )
 from moneyforward_pk.utils.slack_notifier import SlackNotifier
 
@@ -71,7 +71,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _cmd_balances(args: argparse.Namespace) -> str:
-    items = list(load_spider_jsonl(args.input_dir, "mf_transaction"))
+    items = list(load_output_json(args.input_dir, "transaction"))
     monthly = list(filter_year_month(items, args.year, args.month))
     aggregated = bal_mod.aggregate_balances(monthly)
     return bal_mod.report_message(
@@ -80,14 +80,14 @@ def _cmd_balances(args: argparse.Namespace) -> str:
 
 
 def _cmd_asset_allocation(args: argparse.Namespace) -> str:
-    items = list(load_spider_jsonl(args.input_dir, "mf_asset_allocation"))
+    items = list(load_output_json(args.input_dir, "asset_allocation"))
     daily = list(filter_year_month_day(items, args.year, args.month, args.day))
     aggregated = aa_mod.aggregate_asset_allocation(daily)
     return aa_mod.report_message(aggregated, args.year, args.month, args.day)
 
 
 def _cmd_balances_csv(args: argparse.Namespace) -> str:
-    items = list(load_spider_jsonl(args.input_dir, "mf_transaction"))
+    items = list(load_output_json(args.input_dir, "transaction"))
     monthly_aggregates: dict[int, dict] = {}
     for month in range(1, 13):
         m_items = list(filter_year_month(items, args.year, month))

--- a/tests/test_reports_balances_unit.py
+++ b/tests/test_reports_balances_unit.py
@@ -11,7 +11,7 @@ from moneyforward_pk.reports import balances as bal_mod
 from moneyforward_pk.reports._loader import (
     filter_year_month,
     iter_jsonl,
-    load_spider_jsonl,
+    load_output_json,
 )
 
 FIXTURE = Path(__file__).parent / "fixtures" / "reports" / "sample_transactions.jsonl"
@@ -123,17 +123,15 @@ def test_report_csv_year_summary_has_three_sections():
     assert "支出合計" in csv_text
 
 
-def test_load_spider_jsonl_finds_files(tmp_path: Path):
-    target = tmp_path / "mf_transaction_20260425.jsonl"
-    target.write_text(json.dumps({"x": 1}) + "\n", encoding="utf-8")
-    other = tmp_path / "other_spider_20260425.jsonl"
-    other.write_text(json.dumps({"x": 2}) + "\n", encoding="utf-8")
-    items = list(load_spider_jsonl(tmp_path, "mf_transaction"))
-    assert items == [{"x": 1}]
+def test_load_output_json_finds_file(tmp_path: Path):
+    target = tmp_path / "moneyforward_transaction.json"
+    target.write_text(json.dumps([{"x": 1}, {"x": 2}]), encoding="utf-8")
+    items = list(load_output_json(tmp_path, "transaction"))
+    assert items == [{"x": 1}, {"x": 2}]
 
 
-def test_load_spider_jsonl_missing_dir(tmp_path: Path):
-    assert list(load_spider_jsonl(tmp_path / "missing", "mf_transaction")) == []
+def test_load_output_json_missing_file(tmp_path: Path):
+    assert list(load_output_json(tmp_path, "transaction")) == []
 
 
 def test_iter_jsonl_skips_blank_lines(tmp_path: Path):

--- a/tests/test_reports_cli_unit.py
+++ b/tests/test_reports_cli_unit.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-import shutil
+import json
 from pathlib import Path
 
 import pytest
 
+from moneyforward_pk.reports._loader import iter_jsonl
 from moneyforward_pk.reports.cli import main
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "reports"
@@ -14,18 +15,18 @@ FIXTURE_DIR = Path(__file__).parent / "fixtures" / "reports"
 
 @pytest.fixture
 def transaction_dir(tmp_path: Path) -> Path:
-    """JSONL fixture を spider 名 prefix にリネームした作業ディレクトリ。"""
-    src = FIXTURE_DIR / "sample_transactions.jsonl"
-    dst = tmp_path / "mf_transaction_20260425.jsonl"
-    shutil.copyfile(src, dst)
+    """JSONL fixture を新形式 moneyforward_transaction.json (JSON 配列) に変換した作業ディレクトリ。"""
+    records = list(iter_jsonl(FIXTURE_DIR / "sample_transactions.jsonl"))
+    dst = tmp_path / "moneyforward_transaction.json"
+    dst.write_text(json.dumps(records), encoding="utf-8")
     return tmp_path
 
 
 @pytest.fixture
 def asset_allocation_dir(tmp_path: Path) -> Path:
-    src = FIXTURE_DIR / "sample_asset_allocation.jsonl"
-    dst = tmp_path / "mf_asset_allocation_20260425.jsonl"
-    shutil.copyfile(src, dst)
+    records = list(iter_jsonl(FIXTURE_DIR / "sample_asset_allocation.jsonl"))
+    dst = tmp_path / "moneyforward_asset_allocation.json"
+    dst.write_text(json.dumps(records), encoding="utf-8")
     return tmp_path
 
 


### PR DESCRIPTION
## Summary

- `load_spider_jsonl`（旧 JSONL glob）を `load_output_json` に置き換え
- `moneyforward_{type}.json`（JSON 配列）を読むよう変更
- `cli.py` の spider_prefix hardcode (`mf_transaction` 等) を修正
- `.workbench/alias_rules` に `report-bal` / `report-asset` / `report-csv` を追加

## Test plan

- [x] `test_reports_balances_unit.py` — `load_output_json` テストに更新、全パス
- [x] `test_reports_cli_unit.py` — fixture を新形式 JSON 配列に変更、全パス
- [x] 244 tests passed、coverage 84%
- [x] 実データ (`runtime/output/moneyforward_*.json`) で CLI 動作確認済み

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)