### PR TITLE
feat(inspector): html_inspector を smbcnikko_pk 相当に強化 (#57)

### DIFF
--- a/plan/20260504_1649_html_inspector_improvement.md
+++ b/plan/20260504_1649_html_inspector_improvement.md
@@ -1,0 +1,87 @@
+# html_inspector smbcnikko_pk 相当強化
+
+作成: 2026-05-04 16:49  
+Issue: #57  
+Branch: `feature/57_html_inspector_improvement`
+
+---
+
+## 背景・議論サマリ
+
+現状の `HtmlInspectorMiddleware` はすべてのダンプを `runtime/inspect/` 直下にフラット出力しており、複数実行の混在・フロー追跡が困難。
+
+smbcnikko_pk の inspector 実装と比較し、以下を決定した。
+
+### smbcnikko_pk との差分分析
+
+| 機能 | smbcnikko_pk | moneyforward_pk (現状) | 方針 |
+|------|-------------|----------------------|------|
+| 実行単位サブディレクトリ | あり | なし | 移植 |
+| flow.log (JSONL) | あり | なし | 移植 |
+| URL パターンフィルタリング | あり（SMBC固有パス用） | なし | **不要**（master switch で十分） |
+| Playwright load 補足 | あり | なし | 移植 |
+| spider_opened/closed シグナル | あり | なし | 移植 |
+| URL → フォルダ構造 | SMBC固有URL除去ロジックあり | なし | MF独自実装（パス直マッピング） |
+| エラーページ検出 | CSS + NOLコード正規表現（SMBC固有） | なし | MF独自実装（HTTP status >= 400） |
+| charset 修正 | Shift_JIS → utf-8 | 不要 | 不要（MFページはUTF-8） |
+
+### URL マッピング方針
+
+SMBC は `/OdrMng/{onetime_code}/sinyo/genbiki` のようなワンタイムコードを除去する必要があるが、MF のURL構造にはそのような要素がない。URL path をそのままサブディレクトリにマッピングするだけで十分。
+
+例: `https://moneyforward.com/accounts/show` → `accounts/show.html`
+
+### エラー検出方針
+
+SMBC 固有の `span.txt_b02` CSS / `NOL\d{5}E` 正規表現は不要。  
+`response.status >= 400` をエラーとし `_error.html` suffix を付与。
+
+---
+
+## 出力構造（変更後）
+
+```
+runtime/inspect/
+└── {YYYYMMDD_HHMMSS}_{spider}/
+    ├── flow.log                    ← 遷移シーケンス（JSONL）
+    ├── accounts/
+    │   ├── 001_show.html
+    │   └── 002_edit.html
+    └── transactions/
+        └── 003_index.html
+```
+
+**flow.log エントリ例:**
+```json
+{"seq": 1, "time": "13:20:01", "callback": "parse_accounts", "path": "accounts/show", "file": "accounts/001_show.html", "error": false, "query": ""}
+```
+
+---
+
+## 設定キー
+
+| キー | デフォルト | 説明 |
+|------|-----------|------|
+| `MONEYFORWARD_HTML_INSPECTOR` | `false` | マスタースイッチ |
+| `MONEYFORWARD_HTML_INSPECTOR_DIR` | `""` | 出力ディレクトリ上書き |
+
+---
+
+## 変更スコープ
+
+- `src/moneyforward/middlewares/html_inspector.py` — 全面書き換え
+- `tests/test_html_inspector_middleware_unit.py` — テスト更新
+
+---
+
+## 実装手順
+
+1. `html_inspector.py` 書き換え
+   - `from_crawler`: `run_dir` は `spider_opened` で確定
+   - `spider_opened`: `run_dir = base / f"{ts}_{spider.name}"`、flow.log open
+   - `spider_closed`: flow.log close
+   - `process_response`: `_save` → Playwright listener attach
+   - `_save`: URL path → サブディレクトリ変換、HTTP status エラー判定、flow.log 追記
+   - `_attach_playwright_listener`: `page.on("load")` 登録
+2. テスト更新
+3. lint / pyright / pytest 通過確認

--- a/src/moneyforward/middlewares/html_inspector.py
+++ b/src/moneyforward/middlewares/html_inspector.py
@@ -1,37 +1,54 @@
 """Opt-in middleware that dumps response HTML for offline inspection.
 
 Activated only when ``MONEYFORWARD_HTML_INSPECTOR=true`` is set (env or
-Scrapy setting). Off by default so production runs and the existing test
-suite see no behavioural change. Dumps land in
-``runtime/inspect/{spider}_{YYYYmmddHHMMSS}_{seq}.html`` so successive
-requests on a single spider run never collide.
+Scrapy setting). Off by default so production runs see no behavioural change.
 
-This restores the legacy ``scrapy_moneyforward`` HTML-debug capability
-that was lost during the Playwright rebuild.
+Output structure::
+
+    runtime/inspect/{YYYYMMDD_HHMMSS}_{spider}/
+    ├── flow.log                    # navigation sequence (JSONL)
+    ├── accounts/
+    │   ├── 001_show.html
+    │   └── 002_edit.html
+    └── transactions/
+        └── 003_index.html
+
+HTTP 4xx/5xx responses get an ``_error`` suffix. Playwright internal
+navigations are captured via ``page.on("load")``.
 """
 
 from __future__ import annotations
 
+import json
 import logging
-import re
-import time
+import shlex
+import sys
+import weakref
+from datetime import datetime
 from pathlib import Path
+from typing import IO
+from urllib.parse import urlparse
+
+from scrapy import signals
 
 from moneyforward.utils.paths import sanitize_spider_name
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_SUBDIR = "inspect"
-_TS_FORMAT = "%Y%m%d%H%M%S"
-
 
 def _is_truthy(value: object) -> bool:
-    """Return True when ``value`` looks like an enabling flag."""
     if isinstance(value, bool):
         return value
     if value is None:
         return False
     return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _extract_sub_path(url: str) -> str:
+    """Map URL path to a filesystem sub-path, removing traversal segments."""
+    path = urlparse(url).path.strip("/")
+    safe_parts = [p for p in path.split("/") if p and p != ".."]
+    return "/".join(safe_parts) or "index"
 
 
 class HtmlInspectorMiddleware:
@@ -40,7 +57,7 @@ class HtmlInspectorMiddleware:
     Parameters
     ----------
     output_dir : Path
-        Directory under which dumps are written. Created on first use.
+        Base directory under which per-run subdirectories are created.
     enabled : bool
         Master switch. When False, ``process_response`` is a no-op.
     """
@@ -48,11 +65,13 @@ class HtmlInspectorMiddleware:
     def __init__(self, output_dir: Path, *, enabled: bool) -> None:
         self.output_dir = output_dir
         self.enabled = enabled
+        self.run_dir = output_dir
         self._seq = 0
+        self._flow_fh: IO[str] | None = None
+        self._playwright_pages: weakref.WeakSet[object] = weakref.WeakSet()
 
     @classmethod
     def from_crawler(cls, crawler) -> "HtmlInspectorMiddleware":
-        """Build the middleware from Scrapy settings (env-overridable)."""
         settings = crawler.settings
         enabled = _is_truthy(settings.get("MONEYFORWARD_HTML_INSPECTOR", False))
         runtime_dir = Path(
@@ -63,45 +82,137 @@ class HtmlInspectorMiddleware:
         if custom_dir:
             output_dir = Path(custom_dir)
             if not output_dir.is_absolute():
-                output_dir = runtime_dir / output_dir
+                output_dir = runtime_dir / custom_dir
         else:
-            output_dir = runtime_dir / "runtime" / _DEFAULT_SUBDIR
-        return cls(output_dir=output_dir, enabled=enabled)
+            output_dir = runtime_dir / "runtime" / "inspect"
+        inst = cls(output_dir=output_dir, enabled=enabled)
+        if enabled:
+            crawler.signals.connect(inst.spider_opened, signal=signals.spider_opened)
+            crawler.signals.connect(inst.spider_closed, signal=signals.spider_closed)
+        return inst
+
+    # ------------------------------------------------------------------
+    # Spider signals
+    # ------------------------------------------------------------------
+
+    def spider_opened(self, spider) -> None:
+        self._seq = 0
+        self._playwright_pages = weakref.WeakSet()
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        spider_name = sanitize_spider_name(getattr(spider, "name", "spider"))
+        self.run_dir = self.output_dir / f"{ts}_{spider_name}"
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        self._flow_fh = (self.run_dir / "flow.log").open("w", encoding="utf-8")
+        meta = {
+            "type": "meta",
+            "spider": spider_name,
+            "command": shlex.join(sys.argv),
+            "started": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        }
+        self._flow_fh.write(json.dumps(meta, ensure_ascii=False) + "\n")
+        self._flow_fh.flush()
+        logger.debug("HtmlInspector: started. output=%s", self.run_dir)
+
+    def spider_closed(self, spider) -> None:
+        if self._flow_fh:
+            self._flow_fh.close()
+            self._flow_fh = None
+        logger.debug("HtmlInspector: finished. output=%s", self.run_dir)
+
+    # ------------------------------------------------------------------
+    # Scrapy middleware interface
+    # ------------------------------------------------------------------
 
     def process_response(self, request, response, spider):
-        """Dump ``response.body`` when enabled, then pass the response on."""
         if not self.enabled:
+            return response
+        # Require spider_opened to have been called (run_dir and flow.log ready).
+        if self._flow_fh is None:
             return response
         body = getattr(response, "body", None)
         if not body:
             return response
         try:
-            self._dump(spider, response)
-        except OSError as exc:  # disk full / permissions / locked file
-            spider.logger.debug("HtmlInspector skip: %s", exc)
+            html = (
+                response.text
+                if hasattr(response, "text")
+                else body.decode("utf-8", errors="replace")
+            )
+            status = getattr(response, "status", 200)
+            callback = getattr(request.callback, "__name__", None)
+            self._save(html, response.url, status=status, callback=callback)
+            page = request.meta.get("playwright_page")
+            if page is not None:
+                self._attach_playwright_listener(page, callback=callback)
+        except Exception as exc:  # noqa: BLE001
+            spider.logger.warning("HtmlInspector skip: %s", exc)
         return response
 
-    def _dump(self, spider, response) -> None:
-        """Write the response HTML to a unique path under ``output_dir``."""
-        self.output_dir.mkdir(parents=True, exist_ok=True)
+    # ------------------------------------------------------------------
+    # Playwright listener
+    # ------------------------------------------------------------------
+
+    def _attach_playwright_listener(self, page, callback: str | None = None) -> None:
+        if page in self._playwright_pages:
+            return
+        self._playwright_pages.add(page)
+        inspector = self
+        load_callback = f"{callback}->load" if callback else "playwright->load"
+
+        async def on_load() -> None:
+            try:
+                url = page.url
+                html = await page.content()
+                inspector._save(html, url, status=200, callback=load_callback)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("HtmlInspector: load handler error: %s", exc)
+
+        page.on("load", on_load)
+
+    # ------------------------------------------------------------------
+    # Core save logic
+    # ------------------------------------------------------------------
+
+    def _save(
+        self, html: str, url: str, *, status: int = 200, callback: str | None = None
+    ) -> None:
+        parsed = urlparse(url)
+        is_error = status >= 400
+        sub_path = _extract_sub_path(url)
         self._seq += 1
-        spider_name = sanitize_spider_name(getattr(spider, "name", "spider"))
-        ts = time.strftime(_TS_FORMAT)
-        slug = _slugify_url(getattr(response, "url", ""))
-        suffix = f"_{slug}" if slug else ""
-        target = self.output_dir / f"{spider_name}_{ts}_{self._seq:04d}{suffix}.html"
-        body = response.body
-        if isinstance(body, str):
-            target.write_text(body, encoding="utf-8")
-        else:
-            target.write_bytes(body)
-        spider.logger.debug("HtmlInspector dump: %s", target)
+        filepath = self._resolve_filepath(sub_path, is_error)
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        filepath.write_text(html, encoding="utf-8")
+        self._append_flow(parsed.query, sub_path, filepath, is_error, callback=callback)
+        logger.debug("HtmlInspector dump: %s", filepath)
 
+    def _resolve_filepath(self, sub_path: str, is_error: bool) -> Path:
+        parts = sub_path.rsplit("/", 1)
+        dir_part = parts[0] if len(parts) == 2 else ""
+        name = parts[-1] or "index"
+        seq = f"{self._seq:03d}"
+        filename = f"{seq}_{name}_error.html" if is_error else f"{seq}_{name}.html"
+        return self.run_dir / dir_part / filename
 
-def _slugify_url(url: str) -> str:
-    """Reduce a URL to a short filesystem-safe slug (max 40 chars)."""
-    if not url:
-        return ""
-    slug = re.sub(r"^https?://", "", url)
-    slug = re.sub(r"[^A-Za-z0-9_-]+", "_", slug).strip("_")
-    return slug[:40]
+    def _append_flow(
+        self,
+        query: str,
+        path: str,
+        filepath: Path,
+        is_error: bool,
+        *,
+        callback: str | None = None,
+    ) -> None:
+        if self._flow_fh is None:
+            return
+        entry: dict[str, object] = {
+            "seq": self._seq,
+            "time": datetime.now().strftime("%H:%M:%S"),
+            "callback": callback or "",
+            "path": path,
+            "file": str(filepath.relative_to(self.run_dir)).replace("\\", "/"),
+            "error": is_error,
+            "query": query,
+        }
+        self._flow_fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        self._flow_fh.flush()

--- a/tests/test_html_inspector_middleware_unit.py
+++ b/tests/test_html_inspector_middleware_unit.py
@@ -2,24 +2,74 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 from scrapy.http import HtmlResponse, Request
 
-from moneyforward.middlewares.html_inspector import HtmlInspectorMiddleware
+from moneyforward.middlewares.html_inspector import (
+    HtmlInspectorMiddleware,
+    _extract_sub_path,
+)
 
 
-def _spider():
+def _spider(name: str = "mf_test"):
     s = MagicMock()
-    s.name = "mf_test"
+    s.name = name
     s.logger = MagicMock()
     return s
 
 
-def _response(url="https://moneyforward.com/cf", body=b"<html>x</html>"):
-    return HtmlResponse(url=url, body=body, request=Request(url=url))
+def _response(url="https://moneyforward.com/cf", body=b"<html>x</html>", status=200):
+    return HtmlResponse(url=url, body=body, status=status, request=Request(url=url))
+
+
+def _enabled_mw(tmp_path: Path) -> tuple[HtmlInspectorMiddleware, MagicMock]:
+    mw = HtmlInspectorMiddleware(output_dir=tmp_path / "inspect", enabled=True)
+    spider = _spider()
+    mw.spider_opened(spider)
+    return mw, spider
+
+
+# ------------------------------------------------------------------
+# _extract_sub_path
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://moneyforward.com/accounts/show", "accounts/show"),
+        ("https://moneyforward.com/cf", "cf"),
+        ("https://moneyforward.com/", "index"),
+        ("https://moneyforward.com", "index"),
+        ("https://moneyforward.com/a/b/c", "a/b/c"),
+    ],
+)
+def test_extract_sub_path(url, expected):
+    assert _extract_sub_path(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://moneyforward.com/../../etc/passwd",
+        "https://moneyforward.com/../secret",
+        "https://moneyforward.com/accounts/../../etc/shadow",
+    ],
+)
+def test_extract_sub_path_rejects_traversal(url):
+    result = _extract_sub_path(url)
+    assert (
+        ".." not in result
+    )  # traversal segments stripped; remaining path stays in run_dir
+
+
+# ------------------------------------------------------------------
+# Disabled middleware
+# ------------------------------------------------------------------
 
 
 def test_disabled_middleware_does_not_create_files(tmp_path):
@@ -36,35 +86,196 @@ def test_disabled_middleware_returns_same_response(tmp_path):
     assert mw.process_response(Request(url=resp.url), resp, _spider()) is resp
 
 
+# ------------------------------------------------------------------
+# spider_opened / spider_closed
+# ------------------------------------------------------------------
+
+
+def test_spider_opened_creates_run_dir_and_flow_log(tmp_path):
+    mw = HtmlInspectorMiddleware(output_dir=tmp_path / "inspect", enabled=True)
+    spider = _spider("transaction")
+    mw.spider_opened(spider)
+    assert mw.run_dir.exists()
+    assert mw.run_dir.name.endswith("_transaction")
+    flow_log = mw.run_dir / "flow.log"
+    assert flow_log.exists()
+    meta = json.loads(flow_log.read_text(encoding="utf-8").splitlines()[0])
+    assert meta["type"] == "meta"
+    assert meta["spider"] == "transaction"
+
+
+def test_spider_opened_resets_seq(tmp_path):
+    mw = HtmlInspectorMiddleware(output_dir=tmp_path / "inspect", enabled=True)
+    spider = _spider()
+    mw.spider_opened(spider)
+    resp = _response()
+    mw.process_response(Request(url=resp.url), resp, spider)
+    assert mw._seq == 1
+    mw.spider_opened(spider)
+    assert mw._seq == 0
+
+
+def test_spider_closed_closes_flow_log(tmp_path):
+    mw, spider = _enabled_mw(tmp_path)
+    assert mw._flow_fh is not None
+    mw.spider_closed(spider)
+    assert mw._flow_fh is None
+
+
+def test_process_response_before_spider_opened_is_noop(tmp_path):
+    mw = HtmlInspectorMiddleware(output_dir=tmp_path / "inspect", enabled=True)
+    spider = _spider()
+    resp = _response()
+    result = mw.process_response(Request(url=resp.url), resp, spider)
+    assert result is resp
+    assert (
+        not list((tmp_path / "inspect").rglob("*.html"))
+        if (tmp_path / "inspect").exists()
+        else True
+    )
+
+
+# ------------------------------------------------------------------
+# Dump content and structure
+# ------------------------------------------------------------------
+
+
 def test_enabled_middleware_dumps_html(tmp_path):
-    out_dir = tmp_path / "inspect"
-    mw = HtmlInspectorMiddleware(output_dir=out_dir, enabled=True)
+    mw, spider = _enabled_mw(tmp_path)
     resp = _response(body=b"<html><body>secret-marker</body></html>")
-    mw.process_response(Request(url=resp.url), resp, _spider())
-    files = list(out_dir.glob("*.html"))
+    mw.process_response(Request(url=resp.url), resp, spider)
+    files = list(mw.run_dir.rglob("*.html"))
     assert len(files) == 1
-    assert b"secret-marker" in files[0].read_bytes()
+    assert "secret-marker" in files[0].read_text(encoding="utf-8")
+
+
+def test_url_path_maps_to_subdirectory(tmp_path):
+    mw, spider = _enabled_mw(tmp_path)
+    resp = _response(url="https://moneyforward.com/accounts/show")
+    mw.process_response(Request(url=resp.url), resp, spider)
+    expected_dir = mw.run_dir / "accounts"
+    assert expected_dir.exists()
+    assert len(list(expected_dir.glob("*.html"))) == 1
+
+
+def test_error_status_gets_error_suffix(tmp_path):
+    mw, spider = _enabled_mw(tmp_path)
+    resp = _response(url="https://moneyforward.com/accounts/show", status=404)
+    mw.process_response(Request(url=resp.url), resp, spider)
+    files = list(mw.run_dir.rglob("*_error.html"))
+    assert len(files) == 1
+
+
+def test_ok_status_has_no_error_suffix(tmp_path):
+    mw, spider = _enabled_mw(tmp_path)
+    resp = _response(url="https://moneyforward.com/accounts/show", status=200)
+    mw.process_response(Request(url=resp.url), resp, spider)
+    files = list(mw.run_dir.rglob("*_error.html"))
+    assert len(files) == 0
 
 
 def test_enabled_middleware_writes_unique_filenames_per_response(tmp_path):
-    out_dir = tmp_path / "inspect"
-    mw = HtmlInspectorMiddleware(output_dir=out_dir, enabled=True)
+    mw, spider = _enabled_mw(tmp_path)
     for i in range(3):
         resp = _response(url=f"https://moneyforward.com/p/{i}", body=b"<html>x</html>")
-        mw.process_response(Request(url=resp.url), resp, _spider())
-    files = list(out_dir.glob("*.html"))
+        mw.process_response(Request(url=resp.url), resp, spider)
+    files = list(mw.run_dir.rglob("*.html"))
     assert len(files) == 3
-    # Filenames must be unique even when rendered within the same second.
     assert len({f.name for f in files}) == 3
 
 
+def test_same_url_twice_writes_two_files(tmp_path):
+    mw, spider = _enabled_mw(tmp_path)
+    for _ in range(2):
+        resp = _response(url="https://moneyforward.com/accounts/show")
+        mw.process_response(Request(url=resp.url), resp, spider)
+    files = list(mw.run_dir.rglob("*.html"))
+    assert len(files) == 2
+
+
 def test_enabled_middleware_handles_empty_body(tmp_path):
-    out_dir = tmp_path / "inspect"
-    mw = HtmlInspectorMiddleware(output_dir=out_dir, enabled=True)
+    mw, spider = _enabled_mw(tmp_path)
     resp = HtmlResponse(url="https://x/", body=b"", request=Request(url="https://x/"))
-    mw.process_response(Request(url=resp.url), resp, _spider())
-    # Empty body means no dump.
-    assert not list(out_dir.glob("*.html")) or out_dir.exists()
+    mw.process_response(Request(url=resp.url), resp, spider)
+    assert not list(mw.run_dir.rglob("*.html"))
+
+
+# ------------------------------------------------------------------
+# flow.log
+# ------------------------------------------------------------------
+
+
+def test_flow_log_contains_entries(tmp_path):
+    mw, spider = _enabled_mw(tmp_path)
+    resp = _response(url="https://moneyforward.com/accounts/show")
+    mw.process_response(Request(url=resp.url), resp, spider)
+    lines = (mw.run_dir / "flow.log").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2  # meta + 1 entry
+    entry = json.loads(lines[1])
+    assert entry["seq"] == 1
+    assert entry["path"] == "accounts/show"
+    assert entry["error"] is False
+
+
+def test_flow_log_error_entry(tmp_path):
+    mw, spider = _enabled_mw(tmp_path)
+    resp = _response(url="https://moneyforward.com/accounts/show", status=500)
+    mw.process_response(Request(url=resp.url), resp, spider)
+    lines = (mw.run_dir / "flow.log").read_text(encoding="utf-8").splitlines()
+    entry = json.loads(lines[1])
+    assert entry["error"] is True
+
+
+def test_flow_log_file_field_uses_forward_slash(tmp_path):
+    mw, spider = _enabled_mw(tmp_path)
+    resp = _response(url="https://moneyforward.com/accounts/show")
+    mw.process_response(Request(url=resp.url), resp, spider)
+    lines = (mw.run_dir / "flow.log").read_text(encoding="utf-8").splitlines()
+    entry = json.loads(lines[1])
+    assert "\\" not in entry["file"]
+
+
+# ------------------------------------------------------------------
+# Playwright listener
+# ------------------------------------------------------------------
+
+
+def test_playwright_listener_registered_once_per_page(tmp_path):
+    mw, spider = _enabled_mw(tmp_path)
+    page = MagicMock()
+    for _ in range(3):
+        req = Request(url="https://moneyforward.com/cf", meta={"playwright_page": page})
+        resp = _response()
+        mw.process_response(req, resp, spider)
+    assert page.on.call_count == 1
+    assert page.on.call_args == call("load", page.on.call_args[0][1])
+
+
+def test_playwright_listener_different_pages_each_registered(tmp_path):
+    mw, spider = _enabled_mw(tmp_path)
+    pages = [MagicMock() for _ in range(3)]
+    for page in pages:
+        req = Request(url="https://moneyforward.com/cf", meta={"playwright_page": page})
+        resp = _response()
+        mw.process_response(req, resp, spider)
+    for page in pages:
+        assert page.on.call_count == 1
+
+
+def test_playwright_listener_callback_label(tmp_path):
+    mw, spider = _enabled_mw(tmp_path)
+    page = MagicMock()
+    req = Request(url="https://moneyforward.com/cf", meta={"playwright_page": page})
+    req.callback = MagicMock(__name__="parse_accounts")
+    resp = _response()
+    mw.process_response(req, resp, spider)
+    assert page.on.called
+    assert page.on.call_args[0][0] == "load"
+
+
+# ------------------------------------------------------------------
+# from_crawler
+# ------------------------------------------------------------------
 
 
 def test_from_crawler_disabled_by_default(tmp_path):
@@ -99,3 +310,37 @@ def test_from_crawler_custom_dir_relative(tmp_path):
     }.get(key, default)
     mw = HtmlInspectorMiddleware.from_crawler(crawler)
     assert mw.output_dir == Path(tmp_path) / "custom" / "sub"
+
+
+def test_from_crawler_custom_dir_absolute(tmp_path):
+    abs_dir = str(tmp_path / "abs_inspect")
+    crawler = MagicMock()
+    crawler.settings.get = lambda key, default=None: {
+        "MONEYFORWARD_HTML_INSPECTOR": True,
+        "MONEYFORWARD_RUNTIME_DIR": str(tmp_path),
+        "MONEYFORWARD_HTML_INSPECTOR_DIR": abs_dir,
+    }.get(key, default)
+    mw = HtmlInspectorMiddleware.from_crawler(crawler)
+    assert mw.output_dir == Path(abs_dir)
+
+
+def test_from_crawler_connects_signals_when_enabled(tmp_path):
+    crawler = MagicMock()
+    crawler.settings.get = lambda key, default=None: {
+        "MONEYFORWARD_HTML_INSPECTOR": True,
+        "MONEYFORWARD_RUNTIME_DIR": str(tmp_path),
+        "MONEYFORWARD_HTML_INSPECTOR_DIR": "",
+    }.get(key, default)
+    HtmlInspectorMiddleware.from_crawler(crawler)
+    assert crawler.signals.connect.called
+
+
+def test_from_crawler_no_signals_when_disabled(tmp_path):
+    crawler = MagicMock()
+    crawler.settings.get = lambda key, default=None: {
+        "MONEYFORWARD_HTML_INSPECTOR": False,
+        "MONEYFORWARD_RUNTIME_DIR": str(tmp_path),
+        "MONEYFORWARD_HTML_INSPECTOR_DIR": "",
+    }.get(key, default)
+    HtmlInspectorMiddleware.from_crawler(crawler)
+    assert not crawler.signals.connect.called


### PR DESCRIPTION
## Summary

- 実行単位サブディレクトリ `{YYYYMMDD_HHMMSS}_{spider}/` で複数実行の混在を解消
- `flow.log` (JSONL) で遷移シーケンス記録（seq / time / callback / path / error / query）
- Playwright `page.on("load")` で JS 内部遷移をキャプチャ
- HTTP status >= 400 → `_error.html` suffix でエラーページ識別
- URL path → フォルダ構造マッピング（smbcnikko_pk のワンタイムコード除去は MF 不要）

## Security / Robustness

- パストラバーサル防御: `..` セグメントを除去
- Playwright リスナー多重登録防止: `WeakSet` でページ追跡
- `spider_opened` 未呼出ガード: `_flow_fh is None` で早期 return
- 例外ハンドリングを `Exception` に拡張し `warning` ログ

## Test plan

- [x] 37 テストケース全 PASS (`pytest tests/test_html_inspector_middleware_unit.py`)
- [x] lint clean (`ruff check`)
- [x] type clean (`pyright`)
- [x] 実動作確認: スクリーンショット参照 (`runtime/inspect/` にサブディレクトリ・flow.log 生成済み)

## Related

Closes #57  
参照実装: `scrapy_smbcnikko_pk/src/smbcnikko/middlewares/html_inspector.py`  
プラン: `plan/20260504_1649_html_inspector_improvement.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)