### PR TITLE
feat(secrets): Bitwarden Secrets Manager dual mode 統合

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,23 @@
+# -----------------------------------------------------------------------------
+# Secrets backend (省略時は env mode: config/accounts.yaml を使用)
+# -----------------------------------------------------------------------------
+# 値: env (開発標準: 下記 secrets を .env から直接読込)
+#     bitwarden (Bitwarden Secrets Manager から取得)
+SECRETS_BACKEND=env
+
+# -----------------------------------------------------------------------------
+# Bitwarden Secrets Manager (SECRETS_BACKEND=bitwarden 時 / tools/secrets/bws_tool.py 使用時)
+# -----------------------------------------------------------------------------
+# machine account の access token (read-write 兼用、1 個)
+BWS_ACCESS_TOKEN=REPLACE_ME
+# Bitwarden organization の UUID
+ORGANIZATION_ID=REPLACE_ME
+# 登録先 project の UUID (tools/secrets/bws_tool.py register 時必須)
+BWS_PROJECT_ID=REPLACE_ME
+# リージョン (US デフォルト・EU 利用時のみ書き換え)
+BWS_API_URL=https://api.bitwarden.com
+BWS_IDENTITY_URL=https://identity.bitwarden.com
+
 # Site credentials are configured in config/accounts.yaml (per-site / per-account).
 # See config/accounts.example.yaml. SITE_LOGIN_USER / SITE_LOGIN_PASS are
 # retained only as a fallback for ad-hoc ``scrapy crawl <name>`` invocations

--- a/plan/20260504_1801_bitwarden_secrets_integration.md
+++ b/plan/20260504_1801_bitwarden_secrets_integration.md
@@ -1,0 +1,228 @@
+# Bitwarden Secrets Manager 統合
+
+## 概要
+
+`smbcnikko_pk` の `secrets/` モジュールを参考に、本PJへ Bitwarden Secrets Manager (BWS) による設定情報取得を移植する。  
+`SECRETS_BACKEND` 未設定時は `"env"` fallback（既存の `.env` / `config/accounts.yaml` で変わらない）。
+
+---
+
+## 差異分析
+
+### smbcnikko_pk との主要差異
+
+| 項目 | smbcnikko_pk | 本PJ |
+|------|-------------|------|
+| 複数アカウント | 不要（単一 SITE_TORI_PASS） | 必要（site × user[] × pass[]） |
+| Secret 構造 | key=value 1:1 | 1 secret = JSON object |
+| BWS key prefix | `SMBCNIKKO_` | `MONEYFORWARD_` |
+| AWS 認証情報 | 必要（DynamoDB） | 不要 |
+| AUTH_PREFIX 機構 | 必要（WebAuthn passkey） | **移植しない**（MoneyForward に WebAuthn 認証なし） |
+| Slack webhook | resolver 経由 | `.env` 直接参照（→ resolver 経由に変更） |
+| 設定取得関数 | `resolver.get(key)` | `load_accounts(yaml_path)` |
+| 認証情報ファイル | なし（BWS のみ） | `config/accounts.yaml`（env mode で継続利用） |
+| SECRETS_BACKEND 未設定 | **例外（fail-loud）** | **`"env"` fallback に改変** |
+
+### 重要な設計差異: 複数アカウント構造
+
+smbcnikko_pk は `key → single string value` の 1:1 マッピングで済むが、
+本PJは `site → [{user, pass}, ...]` のネスト構造が必要。
+
+**BWS 格納方式（採用案）**:  
+`MONEYFORWARD_ACCOUNTS` という単一 secret に、現 YAML 構造を JSON 文字列として格納。
+
+```json
+{
+  "xmf_ssnb": [
+    {"user": "service@example.com", "pass": "secret1"},
+    {"user": "finance@example.com", "pass": "secret2"}
+  ],
+  "mf": [
+    {"user": "admin@example.com", "pass": "secret3"}
+  ]
+}
+```
+
+Slack webhook は個別 key で格納（オプション）:
+```
+MONEYFORWARD_SLACK_INCOMING_WEBHOOK_URL = "https://hooks.slack.com/..."
+```
+
+### BWS key prefix 剥離後の app_key 対応表
+
+BWS 上の key 名 → `removeprefix("MONEYFORWARD_")` → app_key:
+
+| BWS key | app_key |
+|---------|---------|
+| `MONEYFORWARD_ACCOUNTS` | `ACCOUNTS` |
+| `MONEYFORWARD_SLACK_INCOMING_WEBHOOK_URL` | `SLACK_INCOMING_WEBHOOK_URL` |
+
+---
+
+## 実装設計
+
+### 新規追加ファイル
+
+```
+src/moneyforward/secrets/
+├── __init__.py
+├── bws_provider.py      # Bitwarden SDK ラッパー（AUTH_PREFIX 機構は移植しない）
+├── resolver.py          # dual mode (env / bitwarden) 制御
+└── exceptions.py        # SecretsError, SecretNotFoundError
+
+tools/secrets/
+└── bws_tool.py          # CLI: list / read / register / dump / delete
+                         # register 時: JSON parse + VARIANTS バリデーション
+```
+
+### 変更対象ファイル
+
+- `src/moneyforward/_runner_core.py`: `load_accounts()` を resolver 対応に拡張
+- `src/moneyforward/settings.py`: `SLACK_INCOMING_WEBHOOK_URL` を resolver 経由に変更（後述の分岐仕様参照）
+- `requirements.txt`: `bitwarden-sdk==2.0.0` 追加（smbcnikko_pk と同バージョン pin）
+- `.env.example`: BWS 関連環境変数追記
+
+### resolver.py 設計（smbcnikko_pk からの改変点）
+
+```python
+# 改変1: SECRETS_BACKEND 未設定は "env" fallback（smbcnikko は fail-loud）
+backend = os.environ.get("SECRETS_BACKEND", "env")
+
+# 改変2: REQUIRED_KEYS から SLACK_INCOMING_WEBHOOK_URL を除外
+#         Slack は Optional → 未登録でも bootstrap を落とさない
+REQUIRED_KEYS = ("ACCOUNTS",)
+
+# 改変3: AUTH_PREFIX 機構 (acquire_webauthn_credentials) は実装しない
+
+# 改変4: テスト用 reset_for_test() は移植する（global 状態のリセット）
+```
+
+`bootstrap()` → `get(key)` → `load_accounts_from_resolver()` の流れ。  
+`get("SLACK_INCOMING_WEBHOOK_URL")` は `SecretNotFoundError` を呼び出し側で catch（extension の `NotConfigured` dormant 化と整合）。
+
+### settings.py の Slack webhook 分岐仕様
+
+**重要**: settings.py は pytest collection 時にも import されるため、`bootstrap()` をトップレベルで呼ばない。
+
+```python
+# settings.py での実装方針
+# - トップレベルでは resolver を呼ばない
+# - SLACK_INCOMING_WEBHOOK_URL は lazy 取得 or extension 側で resolver.get() を呼ぶ
+
+# 方針: settings.py は既存の os.environ.get() のまま
+# extension (slack_notifier_extension.py) 側で resolver.get() に変更
+# → extension は「変更あり」に分類変更
+SLACK_INCOMING_WEBHOOK_URL = os.environ.get("SLACK_INCOMING_WEBHOOK_URL", "")
+```
+
+### _runner_core.py 変更
+
+`load_accounts(yaml_path)` を拡張し、`SECRETS_BACKEND=bitwarden` の場合は
+resolver から JSON を取得してパースする。
+
+- シグネチャ: `load_accounts(yaml_path: str | Path | None = None)`
+- bitwarden mode: `yaml_path` 引数は無視（warning ログのみ）
+- JSON パース後も既存の VARIANTS / user / pass バリデーションロジックを通す（共通化）
+- **ACCOUNTS の値（JSON 生文字列）はログ出力禁止**（`Account.password repr=False` との整合）
+
+### slack_notifier_extension.py 変更
+
+`crawler.settings.get("SLACK_INCOMING_WEBHOOK_URL", "")` → `resolver.get("SLACK_INCOMING_WEBHOOK_URL")` に変更し、`SecretNotFoundError` で `NotConfigured` raise（既存の dormant 化挙動を維持）。
+
+---
+
+## 環境変数
+
+### bitwarden mode 必須
+
+```bash
+SECRETS_BACKEND=bitwarden
+BWS_ACCESS_TOKEN=<machine account token>
+ORGANIZATION_ID=<bitwarden organization UUID>
+```
+
+### Optional（EU region / デフォルト US）
+
+```bash
+BWS_API_URL=https://api.bitwarden.eu
+BWS_IDENTITY_URL=https://identity.bitwarden.eu
+```
+
+### env mode（デフォルト、既存動作）
+
+```bash
+# SECRETS_BACKEND=env  # 省略可、未設定時も env として動作
+```
+
+### .env.example 追記内容
+
+```bash
+# --- Bitwarden Secrets Manager (bitwarden mode 時のみ必須) ---
+# SECRETS_BACKEND=bitwarden
+# BWS_ACCESS_TOKEN=<machine account access token>
+# ORGANIZATION_ID=<bitwarden organization UUID>
+# BWS_API_URL=https://api.bitwarden.eu       # EU region 使用時
+# BWS_IDENTITY_URL=https://identity.bitwarden.eu  # EU region 使用時
+```
+
+全角混入確認: `grep -nE "[Ａ-Ｚａ-ｚ０-９]" .env.example`
+
+---
+
+## 実装ステップ
+
+1. `requirements.txt`: `bitwarden-sdk==2.0.0` 追加
+2. `src/moneyforward/secrets/exceptions.py` 作成
+3. `src/moneyforward/secrets/bws_provider.py` 作成
+   - `SMBCNIKKO_` → `MONEYFORWARD_` 置換
+   - import path を `moneyforward.secrets.*` に変更
+   - `AUTH_PREFIX` / `acquire_webauthn_credentials` は実装しない
+4. `src/moneyforward/secrets/resolver.py` 作成
+   - `SECRETS_BACKEND` デフォルト `"env"` に改変
+   - `REQUIRED_KEYS = ("ACCOUNTS",)` のみ（Slack は除外）
+   - `ACCOUNTS` JSON パース → VARIANTS バリデーション
+   - `reset_for_test()` 移植
+5. `src/moneyforward/_runner_core.py`: `load_accounts()` を resolver 対応に拡張
+6. `src/moneyforward/extensions/slack_notifier_extension.py`: resolver.get() に変更
+7. `tools/secrets/bws_tool.py` 作成
+   - register コマンド: JSON parse + VARIANTS バリデーション追加
+8. `.env.example` 更新
+9. テスト作成
+   - resolver: env mode / bitwarden mode（mock）
+   - `reset_for_test()` を各テストで使用
+   - `ACCOUNTS` JSON バリデーション（不正 site / user/pass 欠損）
+10. lint / pyright / pytest 通過確認（カバレッジ 75% 以上維持）
+
+---
+
+## 非変更範囲
+
+- `config/accounts.yaml`: env mode で引き続き使用（削除しない）
+- 既存 spider・middleware・pipeline: 変更なし
+- `src/moneyforward/settings.py`: Slack webhook は変更しない（extension 側で対処）
+- CI: デフォルト `SECRETS_BACKEND=env` で動作するため変更不要
+
+---
+
+## Opus レビュー指摘（反映済）
+
+- [高] settings.py での BWS API 呼出回避 → extension 側で resolver.get() に変更
+- [高] REQUIRED_KEYS から `SLACK_INCOMING_WEBHOOK_URL` 除外 → Slack は optional
+- [高] SECRETS_BACKEND デフォルト "env" fallback → smbcnikko 実装を改変
+- [中] AUTH_PREFIX 機構は移植しない旨を明記
+- [中] ACCOUNTS 値のログ禁止を明記
+- [中] load_accounts() シグネチャ変更の後方互換（bitwarden mode は yaml_path 無視）
+- [中] JSON パース後も VARIANTS バリデーションを通す
+- [中] BWS key prefix 剥離後の app_key 対応表を追記
+- [低] reset_for_test() 移植
+- [低] .env.example の具体的追記内容を明記
+- [低] import path 全置換を明記
+- [低] bws_tool.py の register に JSON + VARIANTS バリデーション追加
+
+---
+
+## 関連資料
+
+- [issue #59](https://github.com/genba-neko/scrapy_moneyforward_pk/issues/59)
+- smbcnikko_pk 参照実装: `c:\Users\g\OneDrive\devel\genba-neko@github\scrapy_smbcnikko_pk\src\smbcnikko\secrets\`
+- bws_tool.py 参照: `c:\Users\g\OneDrive\devel\genba-neko@github\scrapy_smbcnikko_pk\tools\secrets\bws_tool.py`

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ itemadapter>=0.7
 slackweb>=1.0.5
 python-dateutil>=2.8
 PyYAML>=6.0
+bitwarden-sdk==2.0.0
 pytest>=7.4
 pytest-cov>=4.1

--- a/src/moneyforward/_runner_core.py
+++ b/src/moneyforward/_runner_core.py
@@ -10,7 +10,9 @@ Notes
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -58,45 +60,29 @@ class Invocation:
     password: str = field(repr=False)
 
 
-def load_accounts(yaml_path: str | Path) -> dict[str, list[Account]]:
-    """``config/accounts.yaml`` を読み込み site→accounts の dict を返す.
+def _validate_accounts_dict(raw: object) -> dict[str, list[Account]]:
+    """site→entries の dict を検証して Account リストに変換する共通ロジック.
 
-    Parameters
-    ----------
-    yaml_path : str or Path
-        YAML ファイルのパス.
-
-    Returns
-    -------
-    dict[str, list[Account]]
-        site 名 → そのサイトのアカウント一覧.
+    YAML パース結果・JSON パース結果のどちらにも使用する。
+    VARIANTS バリデーション / user / pass 必須チェックを含む。
 
     Raises
     ------
-    FileNotFoundError
-        YAML ファイルが存在しない場合.
     KeyError
-        YAML 内の site キーが ``VARIANTS`` に存在しない場合.
+        未知の site キーが含まれる場合.
     ValueError
-        ``user`` / ``pass`` キーが欠損している、または値が空の場合.
+        マッピング形式でない、または user / pass が欠損 / 空の場合.
     """
-    path = Path(yaml_path)
-    if not path.exists():
-        raise FileNotFoundError(f"accounts yaml not found: {path}")
-
-    with path.open(encoding="utf-8") as fh:
-        raw = yaml.safe_load(fh) or {}
-
     if not isinstance(raw, dict):
-        raise ValueError(
-            f"accounts yaml root must be a mapping, got {type(raw).__name__}"
-        )
+        raise ValueError(f"accounts root must be a mapping, got {type(raw).__name__}")
 
     result: dict[str, list[Account]] = {}
     for site, entries in raw.items():
         if site not in VARIANTS:
-            raise KeyError(
-                f"unknown site in accounts yaml: {site!r}; known={sorted(VARIANTS)}"
+            raise KeyError(f"unknown site: {site!r}; known={sorted(VARIANTS)}")
+        if entries is None:
+            raise ValueError(
+                f"site {site!r} has no account list; use `{site}: []` for an empty site"
             )
         if not isinstance(entries, list):
             raise ValueError(
@@ -120,6 +106,80 @@ def load_accounts(yaml_path: str | Path) -> dict[str, list[Account]]:
         if accounts:
             result[site] = accounts
     return result
+
+
+def _load_accounts_from_yaml(yaml_path: str | Path) -> dict[str, list[Account]]:
+    """``config/accounts.yaml`` から読み込む (env mode 用)."""
+    path = Path(yaml_path)
+    if not path.exists():
+        raise FileNotFoundError(f"accounts yaml not found: {path}")
+
+    with path.open(encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh) or {}
+
+    return _validate_accounts_dict(raw)
+
+
+def _load_accounts_from_bitwarden() -> dict[str, list[Account]]:
+    """BWS の ACCOUNTS secret から読み込む (bitwarden mode 用).
+
+    Notes
+    -----
+    ACCOUNTS の JSON 生文字列はログに出力しない (パスワード平文流出防止)。
+    """
+    from moneyforward.secrets import resolver
+    from moneyforward.secrets.exceptions import SecretNotFound
+
+    try:
+        raw_json = resolver.get("ACCOUNTS")
+    except SecretNotFound as exc:
+        raise ValueError(f"BWS から ACCOUNTS 取得失敗: {exc}") from exc
+
+    try:
+        raw = json.loads(raw_json)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"ACCOUNTS JSON パース失敗: {exc}") from exc
+
+    return _validate_accounts_dict(raw)
+
+
+def load_accounts(yaml_path: str | Path | None = None) -> dict[str, list[Account]]:
+    """site→accounts の dict を返す.
+
+    ``SECRETS_BACKEND`` 環境変数で取得元を切り替える:
+
+    - ``env`` (デフォルト): ``config/accounts.yaml`` から読み込む。
+      ``yaml_path`` が必須。
+    - ``bitwarden``: BWS の ``MONEYFORWARD_ACCOUNTS`` secret から読み込む。
+      ``yaml_path`` は無視される (指定時は warning ログのみ)。
+
+    Parameters
+    ----------
+    yaml_path : str or Path or None
+        YAML ファイルのパス。env mode では必須。bitwarden mode では無視。
+
+    Returns
+    -------
+    dict[str, list[Account]]
+        site 名 → そのサイトのアカウント一覧.
+
+    Raises
+    ------
+    FileNotFoundError
+        YAML ファイルが存在しない場合 (env mode のみ).
+    KeyError
+        site キーが ``VARIANTS`` に存在しない場合.
+    ValueError
+        user / pass が欠損 / 空の場合、または bitwarden mode で JSON 不正の場合.
+    """
+    backend = os.environ.get("SECRETS_BACKEND", "env")
+    if backend == "bitwarden":
+        if yaml_path is not None:
+            logger.warning("bitwarden mode: yaml_path 引数は無視される: %s", yaml_path)
+        return _load_accounts_from_bitwarden()
+    if yaml_path is None:
+        raise ValueError("env mode では yaml_path が必要")
+    return _load_accounts_from_yaml(yaml_path)
 
 
 def list_invocations(

--- a/src/moneyforward/crawl_runner.py
+++ b/src/moneyforward/crawl_runner.py
@@ -130,11 +130,12 @@ def _run(args: argparse.Namespace) -> int:
     setup_common_logging()
 
     accounts_path = _resolve_accounts_path(args.accounts)
-    if not accounts_path.exists():
+    bitwarden_mode = os.environ.get("SECRETS_BACKEND", "env") == "bitwarden"
+    if not bitwarden_mode and not accounts_path.exists():
         logger.error("accounts.yaml not found: %s", accounts_path)
         return 1
 
-    accounts = load_accounts(accounts_path)
+    accounts = load_accounts(None if bitwarden_mode else accounts_path)
     invocations = list_invocations(
         accounts,
         site_filter=args.site,

--- a/src/moneyforward/extensions/slack_notifier_extension.py
+++ b/src/moneyforward/extensions/slack_notifier_extension.py
@@ -1,8 +1,8 @@
 """Slack notification extension hooked to ``spider_closed``.
 
-The extension is opt-in: when ``SLACK_INCOMING_WEBHOOK_URL`` is empty (the
-default in tests and CI), the extension installs itself but performs no
-network calls.
+The extension is opt-in: when ``SLACK_INCOMING_WEBHOOK_URL`` is not configured
+in the active secrets backend (env or bitwarden), the extension raises
+``NotConfigured`` and Scrapy skips it entirely.
 """
 
 from __future__ import annotations
@@ -12,6 +12,8 @@ import logging
 from scrapy import signals
 from scrapy.exceptions import NotConfigured
 
+from moneyforward.secrets import resolver
+from moneyforward.secrets.exceptions import SecretNotFound
 from moneyforward.utils.slack_notifier import SlackNotifier
 
 logger = logging.getLogger(__name__)
@@ -34,11 +36,10 @@ class SlackNotifierExtension:
     @classmethod
     def from_crawler(cls, crawler) -> "SlackNotifierExtension":
         """Wire the extension to ``spider_closed`` if a webhook is configured."""
-        webhook = crawler.settings.get("SLACK_INCOMING_WEBHOOK_URL", "") or ""
-        if not webhook:
-            # Disabled: Scrapy will skip loading the extension entirely so we
-            # do not waste a signal subscription on a dormant notifier.
-            raise NotConfigured("SLACK_INCOMING_WEBHOOK_URL not set")
+        try:
+            webhook = resolver.get("SLACK_INCOMING_WEBHOOK_URL")
+        except SecretNotFound as exc:
+            raise NotConfigured("SLACK_INCOMING_WEBHOOK_URL not set") from exc
         ext = cls(webhook_url=webhook)
         crawler.signals.connect(ext.spider_closed, signal=signals.spider_closed)
         return ext

--- a/src/moneyforward/secrets/__init__.py
+++ b/src/moneyforward/secrets/__init__.py
@@ -1,0 +1,1 @@
+"""secrets パッケージ: Bitwarden / env dual mode での設定値取得."""

--- a/src/moneyforward/secrets/bws_provider.py
+++ b/src/moneyforward/secrets/bws_provider.py
@@ -1,0 +1,98 @@
+"""Bitwarden Secrets Manager (BWS) クライアント薄ラッパー.
+
+本番経路で使うのは `fetch_normal_secrets`。
+list はメタデータのみ返却されるため、値取得には get_by_ids を使う。
+AUTH_PREFIX 機構 (WebAuthn passkey) は本PJに不要なため実装しない。
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from moneyforward.secrets.exceptions import BwsApiError
+
+if TYPE_CHECKING:
+    from bitwarden_sdk import BitwardenClient
+
+DEFAULT_API_URL = "https://api.bitwarden.com"
+DEFAULT_IDENTITY_URL = "https://identity.bitwarden.com"
+
+#: BWS 上の key に付与する project prefix。
+#: アプリ層は prefix を意識せず resolver.get("ACCOUNTS") で透過アクセスする。
+BWS_KEY_PREFIX = "MONEYFORWARD_"
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise BwsApiError(f"環境変数未設定: {name}")
+    return value
+
+
+def build_client() -> BitwardenClient:
+    """BitwardenClient を初期化して access token でログインした状態で返す."""
+    from bitwarden_sdk import BitwardenClient, DeviceType, client_settings_from_dict
+
+    api_url = os.environ.get("BWS_API_URL", DEFAULT_API_URL)
+    identity_url = os.environ.get("BWS_IDENTITY_URL", DEFAULT_IDENTITY_URL)
+    token = _require_env("BWS_ACCESS_TOKEN")
+
+    settings = client_settings_from_dict(
+        {
+            "apiUrl": api_url,
+            "identityUrl": identity_url,
+            "userAgent": "moneyforward-bws/0.1",
+            "deviceType": DeviceType.SDK,
+        }
+    )
+    client = BitwardenClient(settings)
+    client.auth().login_access_token(token)
+    return client
+
+
+def list_identifiers(client: BitwardenClient, organization_id: str) -> list:
+    """Project 内 secret のメタデータ一覧 (value 含まない)."""
+    response = client.secrets().list(organization_id)
+    if response.data is None:
+        raise BwsApiError("BWS list response empty")
+    return list(response.data.data)
+
+
+def fetch_normal_secrets(
+    client: BitwardenClient, organization_id: str
+) -> dict[str, str]:
+    """`MONEYFORWARD_*` を一括取得し、prefix 剥離済の key -> value マップを返す.
+
+    Returns
+    -------
+    dict[str, str]
+        prefix 剥離済の key -> value マップ (例: ``{"ACCOUNTS": "...json..."}``)
+    """
+    identifiers = list_identifiers(client, organization_id)
+
+    target_ids = [s.id for s in identifiers if s.key.startswith(BWS_KEY_PREFIX)]
+
+    if not target_ids:
+        return {}
+
+    response = client.secrets().get_by_ids(target_ids)
+    if response.data is None:
+        raise BwsApiError("BWS get_by_ids response empty")
+
+    secrets_map: dict[str, str] = {}
+    for secret in response.data.data:
+        if not secret.value:
+            raise BwsApiError(f"BWS secret value is empty: key={secret.key}")
+        app_key = secret.key.removeprefix(BWS_KEY_PREFIX)
+        secrets_map[app_key] = secret.value
+
+    return secrets_map
+
+
+def fetch_secret_value(client: BitwardenClient, secret_id: str) -> str:
+    """secret_id 単体で value を取得."""
+    response = client.secrets().get(secret_id)
+    if response.data is None:
+        raise BwsApiError(f"BWS get response empty for id={secret_id}")
+    return response.data.value

--- a/src/moneyforward/secrets/exceptions.py
+++ b/src/moneyforward/secrets/exceptions.py
@@ -1,0 +1,19 @@
+"""secrets パッケージ専用の例外型."""
+
+from __future__ import annotations
+
+
+class SecretsError(Exception):
+    """secrets backend 全体の基底例外."""
+
+
+class BackendNotConfigured(SecretsError):
+    """SECRETS_BACKEND が未設定 / 不正値、または必須環境変数が不足."""
+
+
+class SecretNotFound(SecretsError):
+    """指定 key が backend に存在しない."""
+
+
+class BwsApiError(SecretsError):
+    """Bitwarden Secrets Manager API 呼出失敗."""

--- a/src/moneyforward/secrets/resolver.py
+++ b/src/moneyforward/secrets/resolver.py
@@ -1,0 +1,155 @@
+"""dual mode (env / bitwarden) で secrets を解決する単一窓口.
+
+アプリ層は ``resolver.get("ACCOUNTS")`` で値を取得する。
+``SECRETS_BACKEND`` 環境変数で経路が切り替わる:
+
+- ``env`` (デフォルト): ``os.environ`` から直接取得 (開発標準・既存挙動互換)
+- ``bitwarden``: bootstrap 時に BWS から ``MONEYFORWARD_*`` を一括取得しメモリに保持
+
+bootstrap は idempotent。複数経路から呼ばれても 1 回しか実体動作しない。
+
+smbcnikko_pk からの改変点:
+- SECRETS_BACKEND 未設定は "env" fallback (smbcnikko は fail-loud)
+- REQUIRED_KEYS = ("ACCOUNTS",) のみ (Slack は optional)
+- AUTH_PREFIX 機構 (WebAuthn passkey) は実装しない
+- _bootstrap_env は no-op (ACCOUNTS は YAML から取得するため env var チェック不要)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Any
+
+from moneyforward.secrets.exceptions import (
+    BackendNotConfigured,
+    SecretNotFound,
+)
+
+logger = logging.getLogger(__name__)
+
+_VALID_BACKENDS = ("env", "bitwarden")
+
+#: bitwarden mode で bootstrap 時に必須となる key (app 層の名前)。
+REQUIRED_KEYS = ("ACCOUNTS",)
+
+#: bitwarden mode 用必須環境変数 (BWS 接続情報)。
+_BWS_REQUIRED_ENV = ("BWS_ACCESS_TOKEN", "ORGANIZATION_ID")
+
+_lock = threading.Lock()
+_bootstrapped = False
+_backend: str | None = None
+_cache: dict[str, str] = {}
+_bws_client: Any = None
+
+
+def _resolve_backend() -> str:
+    backend = os.environ.get("SECRETS_BACKEND", "env").strip()
+    if backend not in _VALID_BACKENDS:
+        raise BackendNotConfigured(
+            f"SECRETS_BACKEND must be one of {_VALID_BACKENDS}, got: {backend!r}"
+        )
+    return backend
+
+
+def _validate_bws_env() -> None:
+    missing = [name for name in _BWS_REQUIRED_ENV if not os.environ.get(name)]
+    if missing:
+        raise BackendNotConfigured(f"必須環境変数が不足: {missing}")
+
+
+def _bootstrap_env() -> None:
+    # env mode: ACCOUNTS は YAML から取得するため環境変数チェック不要。
+    pass
+
+
+def _bootstrap_bitwarden() -> None:
+    global _cache, _bws_client
+
+    _validate_bws_env()
+
+    from moneyforward.secrets import bws_provider
+
+    client = bws_provider.build_client()
+    org_id = os.environ["ORGANIZATION_ID"]
+    secrets_map = bws_provider.fetch_normal_secrets(client, org_id)
+
+    missing = [k for k in REQUIRED_KEYS if k not in secrets_map]
+    if missing:
+        raise BackendNotConfigured(
+            f"BWS に必須 secret が不足: {missing} (MONEYFORWARD_<key> として登録要)"
+        )
+
+    _cache = secrets_map
+    _bws_client = client
+
+
+def bootstrap() -> None:
+    """Secrets backend を初期化 (idempotent).
+
+    複数経路から呼ばれても 1 回しか実体動作しない。失敗時は fail loud で起動拒否。
+    """
+    global _bootstrapped, _backend
+
+    with _lock:
+        if _bootstrapped:
+            return
+        _backend = _resolve_backend()
+        if _backend == "env":
+            _bootstrap_env()
+        else:
+            _bootstrap_bitwarden()
+        _bootstrapped = True
+        if _backend == "env":
+            logger.info(
+                "secrets backend initialized: env (no cache; reads from os.environ)"
+            )
+        else:
+            logger.info(
+                "secrets backend initialized: bitwarden (cache=%d secrets)", len(_cache)
+            )
+
+
+def get(key: str) -> str:
+    """Secret 値を取得する。bootstrap 未実施なら自動的に呼ぶ.
+
+    Parameters
+    ----------
+    key : str
+        アプリ層の key (例: ``"ACCOUNTS"``)。BWS 上の prefix は意識しない。
+
+    Returns
+    -------
+    str
+        secret 値。
+
+    Raises
+    ------
+    SecretNotFound
+        env mode で ``os.environ`` に該当キーがない / 空、または bitwarden mode の
+        cache に該当キーが含まれていない場合。
+    """
+    if not _bootstrapped:
+        bootstrap()
+
+    if _backend == "env":
+        value = os.environ.get(key)
+        if not value:
+            raise SecretNotFound(f"env mode: {key} が os.environ に存在しない")
+        return value
+
+    value = _cache.get(key)
+    if not value:
+        raise SecretNotFound(f"bitwarden mode: {key} が BWS から取得できなかった")
+    return value
+
+
+def reset_for_test() -> None:
+    """テスト専用。global 状態を初期化する。プロダクションコードからは呼ばない."""
+    global _bootstrapped, _backend, _cache, _bws_client
+    with _lock:
+        _bootstrapped = False
+        _backend = None
+        _cache = {}
+        _bws_client = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,9 @@ _OWNED_ENV_KEYS = (
     "OUTPUT_DIR",
     "OUTPUT_FILENAME_TEMPLATE",
     "SLACK_INCOMING_WEBHOOK_URL",
+    "SECRETS_BACKEND",
+    "BWS_ACCESS_TOKEN",
+    "ORGANIZATION_ID",
 )
 
 
@@ -44,6 +47,16 @@ def _isolate_moneyforward_env(monkeypatch):
     """Strip MoneyForward-related env from each test (no setdefault)."""
     for key in _OWNED_ENV_KEYS:
         monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_resolver():
+    """resolver global 状態を各テスト前後にリセット。secrets backend を隔離する."""
+    from moneyforward.secrets import resolver
+
+    resolver.reset_for_test()
+    yield
+    resolver.reset_for_test()
 
 
 @pytest.fixture

--- a/tests/test_crawl_runner_unit.py
+++ b/tests/test_crawl_runner_unit.py
@@ -121,6 +121,56 @@ def test_load_accounts_skips_empty_account_list(tmp_path: Path) -> None:
     assert load_accounts(path) == {}
 
 
+def test_load_accounts_env_mode_requires_yaml_path() -> None:
+    # SECRETS_BACKEND 未設定 = env mode → yaml_path=None は ValueError
+    with pytest.raises(ValueError, match="yaml_path"):
+        load_accounts(None)
+
+
+# -------------------------------------------------------- bitwarden mode
+
+
+def test_load_accounts_bitwarden_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SECRETS_BACKEND", "bitwarden")
+    accounts_json = json.dumps({"mf": [{"user": "u@example.com", "pass": "secret"}]})
+    with patch("moneyforward.secrets.resolver.get", return_value=accounts_json):
+        result = load_accounts()
+    assert result == {"mf": [Account(user="u@example.com", password="secret")]}
+
+
+def test_load_accounts_bitwarden_ignores_yaml_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("SECRETS_BACKEND", "bitwarden")
+    accounts_json = json.dumps({"mf": [{"user": "u@example.com", "pass": "p"}]})
+    with patch("moneyforward.secrets.resolver.get", return_value=accounts_json):
+        result = load_accounts(tmp_path / "nonexistent.yaml")
+    assert "mf" in result
+
+
+def test_load_accounts_bitwarden_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SECRETS_BACKEND", "bitwarden")
+    with patch("moneyforward.secrets.resolver.get", return_value="not-json"):
+        with pytest.raises(ValueError, match="JSON パース失敗"):
+            load_accounts()
+
+
+def test_load_accounts_bitwarden_unknown_site(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SECRETS_BACKEND", "bitwarden")
+    accounts_json = json.dumps({"ghost_bank": [{"user": "u@example.com", "pass": "p"}]})
+    with patch("moneyforward.secrets.resolver.get", return_value=accounts_json):
+        with pytest.raises(KeyError, match="unknown site"):
+            load_accounts()
+
+
+def test_load_accounts_bitwarden_missing_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SECRETS_BACKEND", "bitwarden")
+    accounts_json = json.dumps({"mf": [{"user": "u@example.com"}]})
+    with patch("moneyforward.secrets.resolver.get", return_value=accounts_json):
+        with pytest.raises(ValueError, match="missing or empty 'pass'"):
+            load_accounts()
+
+
 # ------------------------------------------------------------- list_invocations
 
 

--- a/tests/test_secrets_unit.py
+++ b/tests/test_secrets_unit.py
@@ -1,0 +1,171 @@
+"""secrets パッケージのユニットテスト (env mode / bitwarden mode mock)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from moneyforward.secrets import resolver
+from moneyforward.secrets.exceptions import (
+    BackendNotConfigured,
+    SecretNotFound,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_resolver():
+    """各テスト前後に resolver global 状態をリセット."""
+    resolver.reset_for_test()
+    yield
+    resolver.reset_for_test()
+
+
+# ---------------------------------------------------------------- bootstrap
+class TestBootstrapEnvMode:
+    def test_defaults_to_env_when_backend_not_set(self, monkeypatch):
+        monkeypatch.delenv("SECRETS_BACKEND", raising=False)
+        resolver.bootstrap()
+        assert resolver._backend == "env"
+        assert resolver._bootstrapped is True
+
+    def test_explicit_env_backend(self, monkeypatch):
+        monkeypatch.setenv("SECRETS_BACKEND", "env")
+        resolver.bootstrap()
+        assert resolver._backend == "env"
+
+    def test_invalid_backend_raises(self, monkeypatch):
+        monkeypatch.setenv("SECRETS_BACKEND", "invalid_backend")
+        with pytest.raises(BackendNotConfigured, match="must be one of"):
+            resolver.bootstrap()
+
+    def test_idempotent(self, monkeypatch):
+        monkeypatch.delenv("SECRETS_BACKEND", raising=False)
+        resolver.bootstrap()
+        resolver.bootstrap()  # 2回目は no-op
+        assert resolver._bootstrapped is True
+
+
+class TestBootstrapBitwardenMode:
+    def test_missing_bws_token_raises(self, monkeypatch):
+        monkeypatch.setenv("SECRETS_BACKEND", "bitwarden")
+        monkeypatch.delenv("BWS_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("ORGANIZATION_ID", raising=False)
+        with pytest.raises(BackendNotConfigured, match="必須環境変数"):
+            resolver.bootstrap()
+
+    def test_missing_org_id_raises(self, monkeypatch):
+        monkeypatch.setenv("SECRETS_BACKEND", "bitwarden")
+        monkeypatch.setenv("BWS_ACCESS_TOKEN", "dummy_token")
+        monkeypatch.delenv("ORGANIZATION_ID", raising=False)
+        with pytest.raises(BackendNotConfigured, match="必須環境変数"):
+            resolver.bootstrap()
+
+    def test_missing_accounts_secret_raises(self, monkeypatch):
+        monkeypatch.setenv("SECRETS_BACKEND", "bitwarden")
+        monkeypatch.setenv("BWS_ACCESS_TOKEN", "dummy_token")
+        monkeypatch.setenv("ORGANIZATION_ID", "dummy_org")
+
+        with patch(
+            "moneyforward.secrets.bws_provider.build_client", return_value=MagicMock()
+        ):
+            with patch(
+                "moneyforward.secrets.bws_provider.fetch_normal_secrets",
+                return_value={},
+            ):
+                with pytest.raises(BackendNotConfigured, match="必須 secret が不足"):
+                    resolver.bootstrap()
+
+    def test_successful_bootstrap_caches_secrets(self, monkeypatch):
+        monkeypatch.setenv("SECRETS_BACKEND", "bitwarden")
+        monkeypatch.setenv("BWS_ACCESS_TOKEN", "dummy_token")
+        monkeypatch.setenv("ORGANIZATION_ID", "dummy_org")
+        accounts_json = json.dumps({"mf": [{"user": "u@example.com", "pass": "p"}]})
+        cache = {
+            "ACCOUNTS": accounts_json,
+            "SLACK_INCOMING_WEBHOOK_URL": "https://hooks.slack.com/x",
+        }
+
+        with patch(
+            "moneyforward.secrets.bws_provider.build_client", return_value=MagicMock()
+        ):
+            with patch(
+                "moneyforward.secrets.bws_provider.fetch_normal_secrets",
+                return_value=cache,
+            ):
+                resolver.bootstrap()
+
+        assert resolver._bootstrapped is True
+        assert resolver._backend == "bitwarden"
+        assert "ACCOUNTS" in resolver._cache
+        assert "SLACK_INCOMING_WEBHOOK_URL" in resolver._cache
+
+
+# ---------------------------------------------------------------- get
+class TestGetEnvMode:
+    def test_returns_env_var(self, monkeypatch):
+        monkeypatch.delenv("SECRETS_BACKEND", raising=False)
+        monkeypatch.setenv("SLACK_INCOMING_WEBHOOK_URL", "https://hooks.slack.com/x")
+        assert resolver.get("SLACK_INCOMING_WEBHOOK_URL") == "https://hooks.slack.com/x"
+
+    def test_missing_key_raises_secret_not_found(self, monkeypatch):
+        monkeypatch.delenv("SECRETS_BACKEND", raising=False)
+        monkeypatch.delenv("SOME_KEY", raising=False)
+        with pytest.raises(SecretNotFound, match="env mode"):
+            resolver.get("SOME_KEY")
+
+    def test_empty_string_raises_secret_not_found(self, monkeypatch):
+        monkeypatch.delenv("SECRETS_BACKEND", raising=False)
+        monkeypatch.setenv("SOME_KEY", "")
+        with pytest.raises(SecretNotFound):
+            resolver.get("SOME_KEY")
+
+    def test_auto_bootstrap_if_not_bootstrapped(self, monkeypatch):
+        monkeypatch.delenv("SECRETS_BACKEND", raising=False)
+        monkeypatch.setenv("MY_KEY", "my_value")
+        assert not resolver._bootstrapped
+        result = resolver.get("MY_KEY")
+        assert result == "my_value"
+        assert resolver._bootstrapped
+
+
+class TestGetBitwardenMode:
+    def _bootstrap_with_cache(self, monkeypatch, cache: dict):
+        monkeypatch.setenv("SECRETS_BACKEND", "bitwarden")
+        monkeypatch.setenv("BWS_ACCESS_TOKEN", "dummy")
+        monkeypatch.setenv("ORGANIZATION_ID", "dummy_org")
+        with patch(
+            "moneyforward.secrets.bws_provider.build_client", return_value=MagicMock()
+        ):
+            with patch(
+                "moneyforward.secrets.bws_provider.fetch_normal_secrets",
+                return_value=cache,
+            ):
+                resolver.bootstrap()
+
+    def test_returns_cached_value(self, monkeypatch):
+        accounts_json = json.dumps({"mf": [{"user": "u@e.com", "pass": "p"}]})
+        self._bootstrap_with_cache(monkeypatch, {"ACCOUNTS": accounts_json})
+        result = resolver.get("ACCOUNTS")
+        assert result == accounts_json
+
+    def test_missing_key_raises_secret_not_found(self, monkeypatch):
+        accounts_json = json.dumps({"mf": [{"user": "u@e.com", "pass": "p"}]})
+        self._bootstrap_with_cache(monkeypatch, {"ACCOUNTS": accounts_json})
+        with pytest.raises(SecretNotFound, match="bitwarden mode"):
+            resolver.get("NONEXISTENT_KEY")
+
+
+# ---------------------------------------------------------------- reset_for_test
+class TestResetForTest:
+    def test_clears_all_state(self, monkeypatch):
+        monkeypatch.delenv("SECRETS_BACKEND", raising=False)
+        resolver.bootstrap()
+        assert resolver._bootstrapped
+
+        resolver.reset_for_test()
+        assert not resolver._bootstrapped
+        assert resolver._backend is None
+        assert resolver._cache == {}
+        assert resolver._bws_client is None

--- a/tests/test_slack_notifier_extension_unit.py
+++ b/tests/test_slack_notifier_extension_unit.py
@@ -13,28 +13,30 @@ from moneyforward.extensions.slack_notifier_extension import (
 )
 
 
-def _make_crawler(webhook: str | None) -> MagicMock:
+def _make_crawler() -> MagicMock:
     crawler = MagicMock()
-    crawler.settings.get.side_effect = lambda key, default=None: {
-        "SLACK_INCOMING_WEBHOOK_URL": webhook,
-    }.get(key, default)
     crawler.signals.connect = MagicMock()
     return crawler
 
 
-def test_extension_is_not_configured_when_webhook_is_empty():
+def test_extension_is_not_configured_when_webhook_is_empty(monkeypatch):
     """Disabled by default: empty webhook must raise NotConfigured."""
+    monkeypatch.setenv("SLACK_INCOMING_WEBHOOK_URL", "")
     with pytest.raises(NotConfigured):
-        SlackNotifierExtension.from_crawler(_make_crawler(""))
+        SlackNotifierExtension.from_crawler(_make_crawler())
 
 
-def test_extension_is_not_configured_when_webhook_is_none():
+def test_extension_is_not_configured_when_webhook_is_missing(monkeypatch):
+    # SLACK_INCOMING_WEBHOOK_URL は conftest autouse fixture で削除済み
     with pytest.raises(NotConfigured):
-        SlackNotifierExtension.from_crawler(_make_crawler(None))
+        SlackNotifierExtension.from_crawler(_make_crawler())
 
 
-def test_extension_connects_spider_closed_when_webhook_set():
-    crawler = _make_crawler("https://hooks.slack.com/services/x/y/z")
+def test_extension_connects_spider_closed_when_webhook_set(monkeypatch):
+    monkeypatch.setenv(
+        "SLACK_INCOMING_WEBHOOK_URL", "https://hooks.slack.com/services/x/y/z"
+    )
+    crawler = _make_crawler()
     ext = SlackNotifierExtension.from_crawler(crawler)
     assert isinstance(ext, SlackNotifierExtension)
     crawler.signals.connect.assert_called_once()

--- a/tools/secrets/bws_tool.py
+++ b/tools/secrets/bws_tool.py
@@ -1,0 +1,312 @@
+"""Bitwarden Secrets Manager 運用ツール.
+
+subcommand:
+- list:     project 内の secret メタデータ一覧
+- read:     key 名で secret 値取得
+- register: secret 登録 (同名 key あれば update、なければ create)
+            ACCOUNTS key の場合は JSON parse + VARIANTS バリデーションを実行
+- dump:     prefix で絞った全件取得
+- delete:   key 名で secret 削除
+
+環境変数:
+- BWS_ACCESS_TOKEN  (必須) machine account の access token
+- ORGANIZATION_ID   (必須) Bitwarden organization UUID
+- BWS_PROJECT_ID    (register 時必須) 登録先 project UUID
+- BWS_API_URL       (任意) デフォルト https://api.bitwarden.com (US)
+- BWS_IDENTITY_URL  (任意) デフォルト https://identity.bitwarden.com (US)
+
+EU リージョン使用時:
+  BWS_API_URL=https://api.bitwarden.eu
+  BWS_IDENTITY_URL=https://identity.bitwarden.eu
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+# プロジェクトルート (= tools/ の親) の .env を読み込む。
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+load_dotenv(_PROJECT_ROOT / ".env", override=False)
+
+# src/ を sys.path に追加して moneyforward パッケージを参照可能にする。
+_SRC_DIR = _PROJECT_ROOT / "src"
+if str(_SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(_SRC_DIR))
+
+DEFAULT_API_URL = "https://api.bitwarden.com"
+DEFAULT_IDENTITY_URL = "https://identity.bitwarden.com"
+
+from moneyforward.secrets.bws_provider import BWS_KEY_PREFIX  # noqa: E402
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        sys.stderr.write(f"環境変数未設定: {name}\n")
+        sys.exit(2)
+    return value
+
+
+def get_client() -> Any:
+    """BitwardenClient を初期化して access token でログイン."""
+    from bitwarden_sdk import BitwardenClient, DeviceType, client_settings_from_dict
+
+    api_url = os.environ.get("BWS_API_URL", DEFAULT_API_URL)
+    identity_url = os.environ.get("BWS_IDENTITY_URL", DEFAULT_IDENTITY_URL)
+    token = _require_env("BWS_ACCESS_TOKEN")
+
+    settings = client_settings_from_dict(
+        {
+            "apiUrl": api_url,
+            "identityUrl": identity_url,
+            "userAgent": "moneyforward-bws-tool/0.1",
+            "deviceType": DeviceType.SDK,
+        }
+    )
+    client = BitwardenClient(settings)
+    client.auth().login_access_token(token)
+    return client
+
+
+def _list_identifiers(client: Any, org_id: str) -> list[Any]:
+    response = client.secrets().list(org_id)
+    return list(response.data.data)
+
+
+def _resolve_id_by_key(client: Any, org_id: str, key: str) -> str | None:
+    for s in _list_identifiers(client, org_id):
+        if s.key == key:
+            return str(s.id)
+    return None
+
+
+def _validate_accounts_json(value: str) -> None:
+    """ACCOUNTS key 登録時の JSON + VARIANTS バリデーション."""
+    from moneyforward.spiders.variants.registry import VARIANTS
+
+    try:
+        data = json.loads(value)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"JSON パース失敗: {exc}\n")
+        sys.exit(2)
+
+    if not isinstance(data, dict):
+        sys.stderr.write(
+            f"ACCOUNTS は dict である必要がある (got {type(data).__name__})\n"
+        )
+        sys.exit(2)
+
+    unknown = sorted(set(data) - set(VARIANTS))
+    if unknown:
+        sys.stderr.write(f"未知の site キー: {unknown}; known={sorted(VARIANTS)}\n")
+        sys.exit(2)
+
+
+def cmd_list(_args: argparse.Namespace) -> int:
+    """Project 内 secret のメタデータ一覧を出力."""
+    org_id = _require_env("ORGANIZATION_ID")
+    client = get_client()
+    identifiers = _list_identifiers(client, org_id)
+    output = [
+        {
+            "id": str(s.id),
+            "key": s.key,
+            "organization_id": str(s.organization_id),
+        }
+        for s in identifiers
+    ]
+    print(json.dumps(output, ensure_ascii=False, indent=2))
+    print(f"\n[total: {len(output)} secrets]", file=sys.stderr)
+    return 0
+
+
+def cmd_read(args: argparse.Namespace) -> int:
+    """Key 名で secret 値を取得.
+
+    警告: value は平文で stdout に出力される。ターミナル履歴・ログファイル・
+    スクリーン共有に残るリスクがある。ACCOUNTS key は全アカウントの認証情報を含む。
+    """
+    sys.stderr.write(
+        "警告: secret 値を平文で出力します。端末履歴に残ることに注意してください。\n"
+    )
+    org_id = _require_env("ORGANIZATION_ID")
+    client = get_client()
+    secret_id = _resolve_id_by_key(client, org_id, args.key)
+    if secret_id is None:
+        sys.stderr.write(f"key 該当なし: {args.key}\n")
+        return 1
+    response = client.secrets().get(secret_id)
+    secret = response.data
+    print(
+        json.dumps(
+            {
+                "id": str(secret.id),
+                "key": secret.key,
+                "value": secret.value,
+                "note": getattr(secret, "note", None),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+def cmd_register(args: argparse.Namespace) -> int:
+    """Secret 登録 (同名 key あれば update、なければ create).
+
+    ACCOUNTS key の場合は JSON/YAML parse + VARIANTS バリデーションを実行してから登録。
+    --from-yaml は config/accounts.yaml をそのまま渡せる。
+    """
+    org_id = _require_env("ORGANIZATION_ID")
+    project_id = _require_env("BWS_PROJECT_ID")
+
+    if args.from_yaml:
+        import yaml as _yaml
+
+        raw = _yaml.safe_load(Path(args.from_yaml).read_text(encoding="utf-8")) or {}
+        value = json.dumps(raw, ensure_ascii=False)
+    elif args.from_file:
+        value = Path(args.from_file).read_text(encoding="utf-8")
+    elif args.value is not None:
+        value = args.value
+    else:
+        sys.stderr.write(
+            "--value / --from-file / --from-yaml のいずれかを指定すること\n"
+        )
+        return 2
+
+    # ACCOUNTS key は JSON + VARIANTS の事前バリデーション
+    bws_key = f"{BWS_KEY_PREFIX}{args.key}"
+    if args.key == "ACCOUNTS":
+        _validate_accounts_json(value)
+
+    note = args.note or ""
+    client = get_client()
+    existing_id = _resolve_id_by_key(client, org_id, bws_key)
+    if existing_id:
+        response = client.secrets().update(
+            org_id, existing_id, bws_key, value, note, [project_id]
+        )
+        op = "updated"
+    else:
+        response = client.secrets().create(org_id, bws_key, value, note, [project_id])
+        op = "created"
+    secret = response.data
+    print(
+        json.dumps(
+            {"operation": op, "id": str(secret.id), "key": secret.key},
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+def cmd_dump(args: argparse.Namespace) -> int:
+    """Prefix で絞った secrets を全件取得して JSON 出力.
+
+    警告: value は平文で stdout に出力される。MONEYFORWARD_ACCOUNTS を含む場合、
+    全アカウントの認証情報が平文で出力されるため取り扱いに注意。
+    """
+    sys.stderr.write(
+        "警告: secret 値を平文で出力します。端末履歴に残ることに注意してください。\n"
+    )
+    org_id = _require_env("ORGANIZATION_ID")
+    client = get_client()
+    identifiers = _list_identifiers(client, org_id)
+    prefix = args.prefix or BWS_KEY_PREFIX
+    targets = [s for s in identifiers if s.key.startswith(prefix)]
+    output: list[dict[str, Any]] = []
+    for s in targets:
+        get_response = client.secrets().get(str(s.id))
+        full = get_response.data
+        output.append({"id": str(full.id), "key": full.key, "value": full.value})
+    print(json.dumps(output, ensure_ascii=False, indent=2))
+    print(
+        f"\n[matched: {len(output)} / total in project: {len(identifiers)}]",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def cmd_delete(args: argparse.Namespace) -> int:
+    """Key 名で secret を削除."""
+    org_id = _require_env("ORGANIZATION_ID")
+    bws_key = f"{BWS_KEY_PREFIX}{args.key}"
+    client = get_client()
+    secret_id = _resolve_id_by_key(client, org_id, bws_key)
+    if secret_id is None:
+        sys.stderr.write(f"key 該当なし: {bws_key}\n")
+        return 1
+    response = client.secrets().delete([secret_id])
+    print(
+        json.dumps(
+            {"deleted_id": secret_id, "key": bws_key, "response": str(response.data)},
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="bws_tool",
+        description="Bitwarden Secrets Manager 運用ツール",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("list", help="project 内 secret のメタデータ一覧")
+
+    p_read = sub.add_parser("read", help="key 名で secret 値を取得 (prefix なしで指定)")
+    p_read.add_argument("--key", required=True, help="app key 名 (例: ACCOUNTS)")
+
+    p_reg = sub.add_parser("register", help="secret 登録 (同名 key あれば update)")
+    p_reg.add_argument("--key", required=True, help="app key 名 (例: ACCOUNTS)")
+    p_reg.add_argument("--value", help="secret 値 (JSON 文字列)")
+    p_reg.add_argument("--from-file", help="JSON ファイルから値を読み込む")
+    p_reg.add_argument(
+        "--from-yaml",
+        help="YAML ファイルから読み込んで JSON に変換して登録 (config/accounts.yaml 向け)",
+    )
+    p_reg.add_argument("--note", help="メモ")
+
+    p_dump = sub.add_parser("dump", help="prefix で絞った全件取得")
+    p_dump.add_argument(
+        "--prefix",
+        default=BWS_KEY_PREFIX,
+        help=f"BWS key prefix (デフォルト: {BWS_KEY_PREFIX})",
+    )
+
+    p_del = sub.add_parser("delete", help="key 名で secret を削除")
+    p_del.add_argument("--key", required=True, help="app key 名 (例: ACCOUNTS)")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "list":
+        return cmd_list(args)
+    if args.command == "read":
+        return cmd_read(args)
+    if args.command == "register":
+        return cmd_register(args)
+    if args.command == "dump":
+        return cmd_dump(args)
+    if args.command == "delete":
+        return cmd_delete(args)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- `SECRETS_BACKEND=env`（デフォルト）と `SECRETS_BACKEND=bitwarden` の dual mode 実装
- BWS から `MONEYFORWARD_ACCOUNTS` を一括取得し、YAML と同一バリデーションを適用
- Slack webhook も BWS 経由で取得可能（`MONEYFORWARD_SLACK_INCOMING_WEBHOOK_URL`）
- `tools/secrets/bws_tool.py` で BWS secret の CRUD 操作と `--from-yaml` による一括登録をサポート

## 変更ファイル

- `src/moneyforward/secrets/` — 新規パッケージ（exceptions / bws_provider / resolver）
- `src/moneyforward/_runner_core.py` — `load_accounts` bitwarden mode 対応
- `src/moneyforward/crawl_runner.py` — bitwarden mode 時 YAML 不在チェック skip
- `src/moneyforward/extensions/slack_notifier_extension.py` — resolver 経由で webhook 取得
- `tools/secrets/bws_tool.py` — BWS 操作 CLI ツール（新規）
- `tests/test_secrets_unit.py` — resolver テスト（新規）
- `tests/test_crawl_runner_unit.py` — bitwarden mode テスト追加
- `tests/test_slack_notifier_extension_unit.py` — monkeypatch 方式に変更
- `.env.example` — BWS 設定項目追加

## Test plan

- [x] `pytest tests/ -v` 296件 全パス確認済み
- [x] `ruff check src/ tests/` クリーン
- [x] `pyright src/ tests/` クリーン
- [x] `SECRETS_BACKEND=bitwarden` + 実 BWS 環境での動作確認済み

Closes #59