### PR TITLE
feat(output): runtime JSON を pretty print 形式に変更

### DIFF
--- a/src/moneyforward/_runner_core.py
+++ b/src/moneyforward/_runner_core.py
@@ -282,7 +282,7 @@ def finalize_output_files(
         if not path.exists():
             continue
         with path.open("a", encoding="utf-8") as fh:
-            fh.write("]")
+            fh.write("\n]")
 
 
 def summarize(

--- a/src/moneyforward/pipelines.py
+++ b/src/moneyforward/pipelines.py
@@ -103,9 +103,10 @@ class JsonArrayOutputPipeline:
                 "JsonArrayOutputPipeline.process_item called before open_spider"
             )
         record = ItemAdapter(item).asdict()
-        if self._wrote_first_in_run:
-            self._file.write(",")
-        self._file.write(json.dumps(record, ensure_ascii=False, default=str))
+        item_json = json.dumps(record, ensure_ascii=False, default=str, indent=2)
+        indented = "  " + item_json.replace("\n", "\n  ")
+        separator = ",\n" if self._wrote_first_in_run else "\n"
+        self._file.write(separator + indented)
         self._wrote_first_in_run = True
         return item
 

--- a/tests/test_crawl_runner_unit.py
+++ b/tests/test_crawl_runner_unit.py
@@ -293,8 +293,7 @@ def test_finalize_output_files_appends_closing_bracket(tmp_path: Path) -> None:
     for st in SPIDER_TYPES:
         p = tmp_path / f"moneyforward_{st}.json"
         text = p.read_text(encoding="utf-8")
-        # Empty array but valid JSON
-        assert text == "[]"
+        # Empty array but valid JSON (pretty-printed: "[\n]")
         assert json.loads(text) == []
 
 

--- a/tests/test_pipelines_unit.py
+++ b/tests/test_pipelines_unit.py
@@ -48,7 +48,7 @@ def test_pipeline_appends_items_to_pre_initialized_file(tmp_path: Path) -> None:
     text = pre.read_text(encoding="utf-8")
     # Without the closing ``]`` the file is not yet valid JSON; closing is the
     # orchestrator's responsibility. We test the array body here.
-    assert text == '[{"a": 1, "b": "あ"},{"a": 2}'
+    assert text == '[\n  {\n    "a": 1,\n    "b": "あ"\n  },\n  {\n    "a": 2\n  }'
 
 
 def test_pipeline_continues_appending_across_invocations(tmp_path: Path) -> None:
@@ -90,7 +90,7 @@ def test_pipeline_self_initializes_when_file_missing(tmp_path: Path) -> None:
     pipeline.close_spider(spider)
 
     out = tmp_path / "moneyforward_transaction.json"
-    assert out.read_text(encoding="utf-8") == '[{"x": 1}'
+    assert out.read_text(encoding="utf-8") == '[\n  {\n    "x": 1\n  }'
 
 
 def test_pipeline_records_path_in_stats(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- `JsonArrayOutputPipeline.process_item` で `json.dumps(indent=2)` 使用、配列内 2スペースインデント
- アイテム間セパレータを `,\n` に変更
- `finalize_output_files` の閉じブラケットを `\n]` に変更

Close #61

## Test plan

- [ ] `crawl_runner` 経由でクロール実行、出力ファイルが pretty print になることを確認
- [ ] `json.load` で読み込み確認（reports CLI 動作）
- [ ] standalone `scrapy crawl` でも正常動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)