### PR TITLE
feat: AXIOM_TOKEN/AXIOM_ORG_ID を Bitwarden resolver 経由取得に対応 (#73)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,7 @@ LOG_FILE_PATH=runtime/logs/moneyforward.log
 # -----------------------------------------------------------------------------
 # Axiom リモートログ連携 (両方設定時のみ有効 / 空のまま = 無効)
 # https://app.axiom.co/settings/api-tokens から取得
+# [Bitwarden 対象] BWS キー: MONEYFORWARD_AXIOM_TOKEN / MONEYFORWARD_AXIOM_ORG_ID
 # -----------------------------------------------------------------------------
 AXIOM_TOKEN=
 AXIOM_ORG_ID=

--- a/plan/20260506_0847_axiom_bitwarden.md
+++ b/plan/20260506_0847_axiom_bitwarden.md
@@ -1,0 +1,24 @@
+# plan: AXIOM_TOKEN/AXIOM_ORG_ID を Bitwarden から取得 (#73)
+
+## 目的
+
+`_build_axiom_handler()` を `resolver.get()` 経由に切り替え、`SECRETS_BACKEND=bitwarden` 時も AXIOM キーを BWS から取得できるようにする。
+
+## 方針
+
+- `resolver.get(key)` を try/except で包み、失敗時は `os.getenv()` フォールバック
+- env mode 既存挙動変更なし
+- Axiom は optional → `SecretNotFound` は silent skip
+
+## 変更ファイル
+
+- `src/moneyforward/utils/logging_config.py` — `_build_axiom_handler()` を resolver 経由に変更
+- `.env.example` — BWS 登録キー名コメント追記
+- `tests/test_logging_axiom_unit.py` — resolver reset fixture 追加、bitwarden path テスト追加
+
+## ステータス
+
+- [x] 実装
+- [x] テスト
+- [ ] コミット
+- [ ] PR 作成

--- a/src/moneyforward/utils/logging_config.py
+++ b/src/moneyforward/utils/logging_config.py
@@ -18,9 +18,23 @@ _UNSET = object()
 _axiom_handler: logging.Handler | None | object = _UNSET
 
 
+def _resolve_axiom_key(key: str) -> str:
+    try:
+        from moneyforward.secrets import resolver
+        from moneyforward.secrets.exceptions import SecretNotFound
+
+        try:
+            return resolver.get(key).strip()
+        except SecretNotFound:
+            pass
+    except Exception:
+        pass
+    return (os.getenv(key) or "").strip()
+
+
 def _build_axiom_handler() -> logging.Handler | None:
-    token = (os.getenv("AXIOM_TOKEN") or "").strip()
-    org_id = (os.getenv("AXIOM_ORG_ID") or "").strip()
+    token = _resolve_axiom_key("AXIOM_TOKEN")
+    org_id = _resolve_axiom_key("AXIOM_ORG_ID")
     if not (token and org_id):
         return None
     dataset = os.getenv("AXIOM_DATASET", "moneyforward-crawler")

--- a/tests/test_logging_axiom_unit.py
+++ b/tests/test_logging_axiom_unit.py
@@ -33,6 +33,15 @@ def _reset_axiom_singleton():
     _logging_mod._axiom_handler = original
 
 
+@pytest.fixture(autouse=True)
+def _reset_resolver():
+    from moneyforward.secrets import resolver
+
+    resolver.reset_for_test()
+    yield
+    resolver.reset_for_test()
+
+
 @pytest.fixture()
 def _reset_root_logging():
     root = logging.getLogger()
@@ -178,3 +187,44 @@ class TestSetupCommonLoggingAxiomIntegration:
         monkeypatch.setenv("AXIOM_ORG_ID", "my-org")
         setup_common_logging()
         assert mock_handler_cls.return_value in logging.getLogger().handlers
+
+
+class TestBuildAxiomHandlerBitwarden:
+    def test_bitwarden_path_returns_handler(self, fake_axiom):
+        from unittest.mock import patch
+
+        from moneyforward.secrets import resolver
+
+        mock_client_cls, mock_handler_cls = fake_axiom
+        secrets = {"AXIOM_TOKEN": "xaat-bws", "AXIOM_ORG_ID": "bws-org"}
+        with patch.object(resolver, "get", side_effect=lambda k: secrets[k]):
+            result = _build_axiom_handler()
+        mock_client_cls.assert_called_once_with(token="xaat-bws", org_id="bws-org")
+        assert result is mock_handler_cls.return_value
+
+    def test_secret_not_found_falls_back_to_env(self, monkeypatch, fake_axiom):
+        from unittest.mock import patch
+
+        from moneyforward.secrets import resolver
+        from moneyforward.secrets.exceptions import SecretNotFound
+
+        mock_client_cls, mock_handler_cls = fake_axiom
+        monkeypatch.setenv("AXIOM_TOKEN", "xaat-env")
+        monkeypatch.setenv("AXIOM_ORG_ID", "env-org")
+        with patch.object(resolver, "get", side_effect=SecretNotFound("key")):
+            result = _build_axiom_handler()
+        mock_client_cls.assert_called_once_with(token="xaat-env", org_id="env-org")
+        assert result is mock_handler_cls.return_value
+
+    def test_resolver_exception_falls_back_to_env(self, monkeypatch, fake_axiom):
+        from unittest.mock import patch
+
+        from moneyforward.secrets import resolver
+
+        mock_client_cls, mock_handler_cls = fake_axiom
+        monkeypatch.setenv("AXIOM_TOKEN", "xaat-env")
+        monkeypatch.setenv("AXIOM_ORG_ID", "env-org")
+        with patch.object(resolver, "get", side_effect=RuntimeError("bws down")):
+            result = _build_axiom_handler()
+        mock_client_cls.assert_called_once_with(token="xaat-env", org_id="env-org")
+        assert result is mock_handler_cls.return_value


### PR DESCRIPTION
## 概要

_build_axiom_handler() を resolver.get() 経由に切り替え、SECRETS_BACKEND=bitwarden 時も AXIOM キーを BWS から取得できるようにする。

- _resolve_axiom_key(): resolver.get() → SecretNotFound 時 os.getenv() フォールバック
- bitwarden mode: BWS から取得、env mode: 既存挙動維持
- .env.example: BWS キー名コメント追記 (MONEYFORWARD_AXIOM_TOKEN / MONEYFORWARD_AXIOM_ORG_ID)
- テスト: _reset_resolver fixture + bitwarden パス 3 テスト追加

closes #73

## 関連資料

- [plan/20260506_0847_axiom_bitwarden.md](plan/20260506_0847_axiom_bitwarden.md)