### PR TITLE
fix: Pipeline の open/close/process_item から spider 引数除去 (#72)

### DIFF
--- a/plan/20260506_1045_remove_spider_arg_pipelines.md
+++ b/plan/20260506_1045_remove_spider_arg_pipelines.md
@@ -1,0 +1,51 @@
+# fix: Pipeline の open_spider/close_spider/process_item から spider 引数除去 (#72)
+
+## 背景
+
+Scrapy 新バージョンで `open_spider()` / `close_spider()` / `process_item()` への `spider` 引数渡しが非推奨。将来バージョンで引数が渡されなくなり実行時エラー化する。
+
+## 対象
+
+- `src/moneyforward/pipelines/json_array.py` — `JsonArrayOutputPipeline`
+- `src/moneyforward/pipelines/dynamodb.py` — `DynamoDbPipeline`
+
+## 設計
+
+### spider アクセス手段
+
+`DynamoDbPipeline` は既に `from_crawler` で `self.crawler` 保持済み。
+`JsonArrayOutputPipeline` は未保持 → `from_crawler` で `instance.crawler = crawler` 追加。
+
+spider インスタンスは `self.crawler.spider` 経由でアクセス。
+
+### シグネチャ変更
+
+| メソッド | 変更前 | 変更後 |
+|---|---|---|
+| open_spider | `(self, spider)` | `(self)` |
+| close_spider | `(self, spider)` | `(self)` |
+| process_item | `(self, item, spider)` | `(self, item)` |
+
+### ロガー変更
+
+`spider.logger.*` → モジュールレベル `logger.*` に統一。
+
+### JsonArrayOutputPipeline 追加変更
+
+- `__init__`: `self.crawler = None`, `self._spider_name = ""` 追加
+- `from_crawler`: `instance.crawler = crawler` 追加
+- `open_spider`: `spider = self.crawler.spider` で取得, `self._spider_name = spider.name` 保存
+- `close_spider`: `self.crawler.stats.set_value(...)` 経由でパス記録
+
+## テスト更新
+
+- `tests/test_pipelines_unit.py`: spider arg 除去、`pipeline.crawler.spider` セットアップ追加
+- `tests/test_dynamodb_pipeline_unit.py`: spider arg 除去、`pipeline.crawler.spider` セットアップ追加、hook signature テスト更新
+
+## ステータス
+
+- [x] json_array.py 修正
+- [x] dynamodb.py 修正
+- [x] テスト更新
+- [x] pytest パス確認 (40 passed)
+- [ ] PR 作成

--- a/plan/20260506_1045_remove_spider_arg_pipelines.md
+++ b/plan/20260506_1045_remove_spider_arg_pipelines.md
@@ -48,4 +48,4 @@ spider インスタンスは `self.crawler.spider` 経由でアクセス。
 - [x] dynamodb.py 修正
 - [x] テスト更新
 - [x] pytest パス確認 (40 passed)
-- [ ] PR 作成
+- [x] PR 作成 [完了 PR#77 2026-05-06]

--- a/src/moneyforward/pipelines/dynamodb.py
+++ b/src/moneyforward/pipelines/dynamodb.py
@@ -126,12 +126,13 @@ class DynamoDbPipeline:
         instance.crawler = crawler
         return instance
 
-    def open_spider(self, spider) -> None:
+    def open_spider(self) -> None:
+        spider = self.crawler.spider
         self._spider_type = getattr(spider, "spider_type", spider.name)
         self._items = []  # reset buffer on each spider open
         table_name = self.table_names.get(self._spider_type, "")
         if not table_name:
-            spider.logger.info(
+            logger.info(
                 "DynamoDbPipeline: no table configured for spider_type=%r; "
                 "DynamoDB writes will be skipped for this run.",
                 self._spider_type,
@@ -140,7 +141,7 @@ class DynamoDbPipeline:
             return
         db = resolve_dynamodb_resource()
         self.table = db.Table(table_name)
-        spider.logger.info(
+        logger.info(
             "DynamoDbPipeline open: spider_type=%r table=%r",
             self._spider_type,
             table_name,
@@ -178,11 +179,11 @@ class DynamoDbPipeline:
         finally:
             sleep(self.put_delay)
 
-    def close_spider(self, spider) -> None:
+    def close_spider(self) -> None:
         self._batch_flush(is_force=True)
         self.table = None
 
-    def process_item(self, item: Any, spider) -> Any:
+    def process_item(self, item: Any) -> Any:
         if self.table is None:
             return item
         self._items.append(item)

--- a/src/moneyforward/pipelines/json_array.py
+++ b/src/moneyforward/pipelines/json_array.py
@@ -53,6 +53,8 @@ class JsonArrayOutputPipeline:
         self._file: IO[str] | None = None
         self._path: Path | None = None
         self._wrote_first_in_run = False
+        self.crawler: Any = None
+        self._spider_name: str = ""
 
     @classmethod
     def from_crawler(cls, crawler) -> "JsonArrayOutputPipeline":
@@ -61,11 +63,15 @@ class JsonArrayOutputPipeline:
         default_dir = Path(settings.get("OUTPUT_DIR_DEFAULT", "runtime/output"))
         output_dir = resolve_output_dir(settings.get("OUTPUT_DIR", ""), default_dir)
         template = settings.get("OUTPUT_FILENAME_TEMPLATE", DEFAULT_FILENAME_TEMPLATE)
-        return cls(output_dir=output_dir, template=template)
+        instance = cls(output_dir=output_dir, template=template)
+        instance.crawler = crawler
+        return instance
 
-    def open_spider(self, spider) -> None:
+    def open_spider(self) -> None:
         """Open the per-spider-type file in append mode."""
+        spider = self.crawler.spider
         spider_type = getattr(spider, "spider_type", spider.name)
+        self._spider_name = spider.name
         self.output_dir.mkdir(parents=True, exist_ok=True)
         # Issue #40 changed output to a fixed-name 3-file aggregate. If the
         # template does not reference ``{spider_type}``, the configured value
@@ -74,7 +80,7 @@ class JsonArrayOutputPipeline:
         # case and warn the operator instead of producing broken JSON files.
         template = self.template
         if "{spider_type}" not in template:
-            spider.logger.warning(
+            logger.warning(
                 "OUTPUT_FILENAME_TEMPLATE %r is incompatible with Issue #40; "
                 "falling back to %r. Update .env to silence this warning.",
                 template,
@@ -94,9 +100,9 @@ class JsonArrayOutputPipeline:
         size = target.stat().st_size
         self._wrote_first_in_run = size > 1
         self._file = target.open("a", encoding="utf-8")
-        spider.logger.info("JsonArrayOutputPipeline open: path=%s", target)
+        logger.info("JsonArrayOutputPipeline open: path=%s", target)
 
-    def process_item(self, item: Any, spider) -> Any:
+    def process_item(self, item: Any) -> Any:
         """Serialize ``item`` and append to the JSON array."""
         if self._file is None:
             raise RuntimeError(
@@ -110,13 +116,13 @@ class JsonArrayOutputPipeline:
         self._wrote_first_in_run = True
         return item
 
-    def close_spider(self, spider) -> None:
+    def close_spider(self) -> None:
         """Flush + close. Note: closing ``]`` is written by the runner."""
         if self._file is not None:
             self._file.flush()
             self._file.close()
             self._file = None
-        crawler = getattr(spider, "crawler", None)
-        stats = getattr(crawler, "stats", None) if crawler is not None else None
-        if stats is not None and self._path is not None:
-            stats.set_value(f"{spider.name}/output/path", str(self._path))
+        if self.crawler is not None and self._path is not None and self._spider_name:
+            self.crawler.stats.set_value(
+                f"{self._spider_name}/output/path", str(self._path)
+            )

--- a/tests/test_dynamodb_pipeline_unit.py
+++ b/tests/test_dynamodb_pipeline_unit.py
@@ -145,6 +145,8 @@ def test_open_spider_sets_table_when_table_name_configured():
     )
     spider = MagicMock()
     spider.spider_type = "transaction"
+    pipeline.crawler = MagicMock()
+    pipeline.crawler.spider = spider
 
     mock_table = MagicMock()
     mock_resource = MagicMock()
@@ -154,7 +156,7 @@ def test_open_spider_sets_table_when_table_name_configured():
         "moneyforward.pipelines.dynamodb.resolve_dynamodb_resource",
         return_value=mock_resource,
     ):
-        pipeline.open_spider(spider)
+        pipeline.open_spider()
 
     assert pipeline.table is mock_table
     mock_resource.Table.assert_called_once_with("mf_transaction")
@@ -168,9 +170,11 @@ def test_open_spider_leaves_table_none_when_table_name_empty():
     )
     spider = MagicMock()
     spider.spider_type = "transaction"
+    pipeline.crawler = MagicMock()
+    pipeline.crawler.spider = spider
 
     with patch("moneyforward.pipelines.dynamodb.resolve_dynamodb_resource") as mock_res:
-        pipeline.open_spider(spider)
+        pipeline.open_spider()
 
     mock_res.assert_not_called()
     assert pipeline.table is None
@@ -183,6 +187,8 @@ def test_open_spider_resets_buffer():
 
     spider = MagicMock()
     spider.spider_type = "transaction"
+    pipeline.crawler = MagicMock()
+    pipeline.crawler.spider = spider
     mock_resource = MagicMock()
     mock_resource.Table.return_value = MagicMock()
 
@@ -190,7 +196,7 @@ def test_open_spider_resets_buffer():
         "moneyforward.pipelines.dynamodb.resolve_dynamodb_resource",
         return_value=mock_resource,
     ):
-        pipeline.open_spider(spider)
+        pipeline.open_spider()
 
     assert pipeline._items == []
 
@@ -206,10 +212,10 @@ def test_process_item_flushes_when_batch_size_reached(mock_sleep):
     item1 = _make_transaction_item("20260401_001")
     item2 = _make_transaction_item("20260401_002")
 
-    pipeline.process_item(item1, MagicMock())
+    pipeline.process_item(item1)
     assert fake_batch.put_item.call_count == 0
 
-    pipeline.process_item(item2, MagicMock())
+    pipeline.process_item(item2)
     assert fake_batch.put_item.call_count == 2
     assert pipeline.crawler.stats.get_value("moneyforward/dynamodb/items") == 2
     assert pipeline._items == []
@@ -219,7 +225,7 @@ def test_process_item_flushes_when_batch_size_reached(mock_sleep):
 @patch("moneyforward.pipelines.dynamodb.sleep", return_value=None)
 def test_process_item_no_flush_before_batch_size(mock_sleep):
     pipeline, fake_batch = _make_pipeline(batch_n=5)
-    pipeline.process_item(_make_transaction_item(), MagicMock())
+    pipeline.process_item(_make_transaction_item())
     assert fake_batch.put_item.call_count == 0
     mock_sleep.assert_not_called()
 
@@ -229,14 +235,14 @@ def test_process_item_multiple_flushes_across_batches(mock_sleep):
     """T1: 5 items with batch_n=2 → 2 flushes + 1 remaining on close_spider."""
     pipeline, fake_batch = _make_pipeline(batch_n=2)
     for i in range(5):
-        pipeline.process_item(_make_transaction_item(f"20260401_{i:03}"), MagicMock())
+        pipeline.process_item(_make_transaction_item(f"20260401_{i:03}"))
 
     # After 5 items: 2 flushes of 2 items each = 4 PUT calls, 1 item buffered
     assert fake_batch.put_item.call_count == 4
     assert len(pipeline._items) == 1
     assert mock_sleep.call_count == 2
 
-    pipeline.close_spider(MagicMock())
+    pipeline.close_spider()
     assert fake_batch.put_item.call_count == 5
     assert pipeline._items == []
 
@@ -244,9 +250,9 @@ def test_process_item_multiple_flushes_across_batches(mock_sleep):
 @patch("moneyforward.pipelines.dynamodb.sleep", return_value=None)
 def test_close_spider_flushes_remaining_items(mock_sleep):
     pipeline, fake_batch = _make_pipeline(batch_n=10)
-    pipeline.process_item(_make_transaction_item(), MagicMock())
+    pipeline.process_item(_make_transaction_item())
 
-    pipeline.close_spider(MagicMock())
+    pipeline.close_spider()
 
     assert fake_batch.put_item.call_count == 1
     assert pipeline.crawler.stats.get_value("moneyforward/dynamodb/items") == 1
@@ -256,7 +262,7 @@ def test_close_spider_flushes_remaining_items(mock_sleep):
 @patch("moneyforward.pipelines.dynamodb.sleep", return_value=None)
 def test_close_spider_noop_when_buffer_empty(mock_sleep):
     pipeline, fake_batch = _make_pipeline(batch_n=10)
-    pipeline.close_spider(MagicMock())
+    pipeline.close_spider()
     fake_batch.put_item.assert_not_called()
 
 
@@ -269,7 +275,7 @@ def test_process_item_passthrough_when_table_none():
     pipeline, _ = _make_pipeline()
     pipeline.table = None
     item = _make_transaction_item()
-    result = pipeline.process_item(item, MagicMock())
+    result = pipeline.process_item(item)
     assert result is item
     assert pipeline._items == []
 
@@ -277,7 +283,7 @@ def test_process_item_passthrough_when_table_none():
 def test_close_spider_noop_when_table_none():
     pipeline, fake_batch = _make_pipeline()
     pipeline.table = None
-    pipeline.close_spider(MagicMock())
+    pipeline.close_spider()
     fake_batch.put_item.assert_not_called()
 
 
@@ -289,7 +295,7 @@ def test_close_spider_noop_when_table_none():
 @patch("moneyforward.pipelines.dynamodb.sleep", return_value=None)
 def test_batch_writer_called_with_overwrite_pkeys_for_transaction(_sleep):
     pipeline, _ = _make_pipeline(spider_type="transaction", batch_n=1)
-    pipeline.process_item(_make_transaction_item(), MagicMock())
+    pipeline.process_item(_make_transaction_item())
     pipeline.table.batch_writer.assert_called_once_with(
         overwrite_by_pkeys=["year_month", "data_table_sortable_value"]
     )
@@ -305,7 +311,7 @@ def test_batch_writer_called_with_overwrite_pkeys_for_asset_allocation(_sleep):
         "asset_type": "equity",
         "amount_value": 100000,
     }
-    pipeline.process_item(item, MagicMock())
+    pipeline.process_item(item)
     pipeline.table.batch_writer.assert_called_once_with(
         overwrite_by_pkeys=["year_month_day", "asset_item_key"]
     )
@@ -315,7 +321,7 @@ def test_batch_writer_called_with_overwrite_pkeys_for_asset_allocation(_sleep):
 def test_batch_writer_called_without_overwrite_pkeys_for_unknown_spider_type(_sleep):
     """T6: unknown spider_type has no pkeys → batch_writer called with no kwargs."""
     pipeline, _ = _make_pipeline(spider_type="unknown_type", batch_n=1)
-    pipeline.process_item(_make_transaction_item(), MagicMock())
+    pipeline.process_item(_make_transaction_item())
     pipeline.table.batch_writer.assert_called_once_with()
 
 
@@ -330,7 +336,7 @@ def test_batch_flush_raises_dropitem_on_dynamodb_error(_sleep):
     pipeline.table.batch_writer.side_effect = RuntimeError("network error")
 
     with pytest.raises(DropItem):
-        pipeline.process_item(_make_transaction_item(), MagicMock())
+        pipeline.process_item(_make_transaction_item())
 
 
 @patch("moneyforward.pipelines.dynamodb.sleep", return_value=None)
@@ -339,7 +345,7 @@ def test_batch_flush_error_increments_error_stat(_sleep):
     pipeline.table.batch_writer.side_effect = RuntimeError("boom")
 
     with pytest.raises(DropItem):
-        pipeline.process_item(_make_transaction_item(), MagicMock())
+        pipeline.process_item(_make_transaction_item())
 
     assert pipeline.crawler.stats.get_value("moneyforward/dynamodb/errors") == 1
 
@@ -351,7 +357,7 @@ def test_sleep_called_even_on_error(mock_sleep):
     pipeline.table.batch_writer.side_effect = RuntimeError("boom")
 
     with pytest.raises(DropItem):
-        pipeline.process_item(_make_transaction_item(), MagicMock())
+        pipeline.process_item(_make_transaction_item())
 
     mock_sleep.assert_called_once_with(5)
 
@@ -379,7 +385,7 @@ def test_subsequent_items_not_contaminated_after_flush_error(mock_sleep):
 
     # First item → flush fails, buffer cleared via snapshot pattern
     with pytest.raises(DropItem):
-        pipeline.process_item(_make_transaction_item("001"), MagicMock())
+        pipeline.process_item(_make_transaction_item("001"))
 
     assert pipeline._items == []
 
@@ -392,7 +398,7 @@ def test_subsequent_items_not_contaminated_after_flush_error(mock_sleep):
     pipeline.table.batch_writer.return_value = fake_ctx2
 
     next_item = _make_transaction_item("002")
-    result = pipeline.process_item(next_item, MagicMock())
+    result = pipeline.process_item(next_item)
     # batch_n=1 → flushed immediately; PUT called with only the new item
     assert result is next_item
     assert fake_batch2.put_item.call_count == 1
@@ -400,11 +406,11 @@ def test_subsequent_items_not_contaminated_after_flush_error(mock_sleep):
 
 
 # ---------------------------------------------------------------------------
-# Scrapy hook signatures (spider argument)
+# Scrapy hook signatures (no spider argument)
 # ---------------------------------------------------------------------------
 
 
-def test_open_spider_accepts_spider_argument():
+def test_open_spider_works_without_spider_argument():
     pipeline = DynamoDbPipeline(
         table_names={
             "transaction": "mf_transaction",
@@ -416,6 +422,8 @@ def test_open_spider_accepts_spider_argument():
     )
     spider = MagicMock()
     spider.spider_type = "transaction"
+    pipeline.crawler = MagicMock()
+    pipeline.crawler.spider = spider
 
     mock_resource = MagicMock()
     mock_resource.Table.return_value = MagicMock()
@@ -423,24 +431,23 @@ def test_open_spider_accepts_spider_argument():
         "moneyforward.pipelines.dynamodb.resolve_dynamodb_resource",
         return_value=mock_resource,
     ):
-        pipeline.open_spider(spider)
+        pipeline.open_spider()
 
     assert pipeline.table is not None
 
 
 @patch("moneyforward.pipelines.dynamodb.sleep", return_value=None)
-def test_process_item_accepts_spider_argument(_sleep):
+def test_process_item_works_without_spider_argument(_sleep):
     pipeline, _ = _make_pipeline(batch_n=100)
-    spider = MagicMock()
     item = _make_transaction_item()
-    result = pipeline.process_item(item, spider)
+    result = pipeline.process_item(item)
     assert result is item
 
 
-def test_close_spider_accepts_spider_argument():
+def test_close_spider_works_without_spider_argument():
     pipeline, _ = _make_pipeline(batch_n=10)
     pipeline.table = None
-    pipeline.close_spider(MagicMock())
+    pipeline.close_spider()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipelines_unit.py
+++ b/tests/test_pipelines_unit.py
@@ -40,10 +40,12 @@ def test_pipeline_appends_items_to_pre_initialized_file(tmp_path: Path) -> None:
         template="moneyforward_{spider_type}.json",
     )
     spider = _make_spider()
-    pipeline.open_spider(spider)
-    pipeline.process_item({"a": 1, "b": "あ"}, spider)
-    pipeline.process_item({"a": 2}, spider)
-    pipeline.close_spider(spider)
+    pipeline.crawler = MagicMock()
+    pipeline.crawler.spider = spider
+    pipeline.open_spider()
+    pipeline.process_item({"a": 1, "b": "あ"})
+    pipeline.process_item({"a": 2})
+    pipeline.close_spider()
 
     text = pre.read_text(encoding="utf-8")
     # Without the closing ``]`` the file is not yet valid JSON; closing is the
@@ -56,22 +58,27 @@ def test_pipeline_continues_appending_across_invocations(tmp_path: Path) -> None
     pre = tmp_path / "moneyforward_transaction.json"
     pre.write_text("[", encoding="utf-8")
 
+    spider = _make_spider()
+    fake_crawler = MagicMock()
+    fake_crawler.spider = spider
+
     pipeline_a = JsonArrayOutputPipeline(
         output_dir=tmp_path,
         template="moneyforward_{spider_type}.json",
     )
-    spider = _make_spider()
-    pipeline_a.open_spider(spider)
-    pipeline_a.process_item({"a": 1}, spider)
-    pipeline_a.close_spider(spider)
+    pipeline_a.crawler = fake_crawler
+    pipeline_a.open_spider()
+    pipeline_a.process_item({"a": 1})
+    pipeline_a.close_spider()
 
     pipeline_b = JsonArrayOutputPipeline(
         output_dir=tmp_path,
         template="moneyforward_{spider_type}.json",
     )
-    pipeline_b.open_spider(spider)
-    pipeline_b.process_item({"b": 2}, spider)
-    pipeline_b.close_spider(spider)
+    pipeline_b.crawler = fake_crawler
+    pipeline_b.open_spider()
+    pipeline_b.process_item({"b": 2})
+    pipeline_b.close_spider()
 
     # Append the closing bracket the way the orchestrator would.
     pre.write_text(pre.read_text(encoding="utf-8") + "]", encoding="utf-8")
@@ -85,9 +92,11 @@ def test_pipeline_self_initializes_when_file_missing(tmp_path: Path) -> None:
         template="moneyforward_{spider_type}.json",
     )
     spider = _make_spider()
-    pipeline.open_spider(spider)
-    pipeline.process_item({"x": 1}, spider)
-    pipeline.close_spider(spider)
+    pipeline.crawler = MagicMock()
+    pipeline.crawler.spider = spider
+    pipeline.open_spider()
+    pipeline.process_item({"x": 1})
+    pipeline.close_spider()
 
     out = tmp_path / "moneyforward_transaction.json"
     assert out.read_text(encoding="utf-8") == '[\n  {\n    "x": 1\n  }'
@@ -99,9 +108,12 @@ def test_pipeline_records_path_in_stats(tmp_path: Path) -> None:
         template="moneyforward_{spider_type}.json",
     )
     spider = _make_spider()
-    pipeline.open_spider(spider)
-    pipeline.close_spider(spider)
-    spider.crawler.stats.set_value.assert_any_call(
+    pipeline.crawler = MagicMock()
+    pipeline.crawler.spider = spider
+    pipeline.crawler.stats.set_value = MagicMock()
+    pipeline.open_spider()
+    pipeline.close_spider()
+    pipeline.crawler.stats.set_value.assert_any_call(
         "transaction/output/path",
         str(tmp_path / "moneyforward_transaction.json"),
     )
@@ -113,7 +125,7 @@ def test_pipeline_process_item_before_open_raises() -> None:
         template="moneyforward_{spider_type}.json",
     )
     with pytest.raises(RuntimeError):
-        pipeline.process_item({"a": 1}, _make_spider())
+        pipeline.process_item({"a": 1})
 
 
 def test_from_crawler_uses_settings() -> None:


### PR DESCRIPTION
## Summary

- `JsonArrayOutputPipeline` / `DynamoDbPipeline` の `open_spider()` / `close_spider()` / `process_item()` から `spider` 引数除去
- Scrapy 非推奨警告 `ScrapyDeprecationWarning` 解消
- spider アクセスは `self.crawler.spider` 経由に統一。`JsonArrayOutputPipeline` に `self.crawler` 保持を追加

## Test plan

- [x] `tests/test_pipelines_unit.py` — 全テスト更新・パス (40 passed)
- [x] `tests/test_dynamodb_pipeline_unit.py` — 全テスト更新・パス
- [x] pre-push フック (pytest + coverage, ruff, pyright) 全通過

関連資料: [plan/20260506_1045_remove_spider_arg_pipelines.md](plan/20260506_1045_remove_spider_arg_pipelines.md)

Closes #72

🤖 Generated with [Claude Code](https://claude.ai/claude-code)