### PR TITLE
fix: scrapy/scrapy-playwright ログ抑制 + middleware spider 引数除去 (#74)

### DIFF
--- a/plan/20260506_1126_axiom_bitwarden_scrapy_log.md
+++ b/plan/20260506_1126_axiom_bitwarden_scrapy_log.md
@@ -2,7 +2,7 @@
 
 ## ステータス
 
-- [x] `scrapy` を noisy loggers に追加
+- [x] `scrapy` を noisy loggers に追加 [完了 PR#80 2026-05-06]
 
 ## 背景
 

--- a/plan/20260506_1126_axiom_bitwarden_scrapy_log.md
+++ b/plan/20260506_1126_axiom_bitwarden_scrapy_log.md
@@ -1,0 +1,28 @@
+# plan: #74 scrapy INFO ログ抑制
+
+## ステータス
+
+- [x] `scrapy` を noisy loggers に追加
+
+## 背景
+
+issue #74 (訂正済み)。
+
+- ① Bitwarden 対応: PR#73 で実装済み。AXIOM_DATASET は設定値のため BWS 対象外
+- ② scrapy INFO ログ抑制: 未対応 ← **本 plan の対象**
+
+## 変更内容
+
+### `src/moneyforward/utils/logging_config.py` line 113
+
+```python
+# before
+for noisy in ("urllib3", "asyncio", "playwright"):
+# after
+for noisy in ("urllib3", "asyncio", "playwright", "scrapy"):
+```
+
+## 関連
+
+- issue #74
+- PR#73 (AXIOM Bitwarden 対応)

--- a/src/moneyforward/middlewares/html_inspector.py
+++ b/src/moneyforward/middlewares/html_inspector.py
@@ -123,7 +123,7 @@ class HtmlInspectorMiddleware:
     # Scrapy middleware interface
     # ------------------------------------------------------------------
 
-    def process_response(self, request, response, spider):
+    def process_response(self, request, response):
         if not self.enabled:
             return response
         # Require spider_opened to have been called (run_dir and flow.log ready).
@@ -145,7 +145,7 @@ class HtmlInspectorMiddleware:
             if page is not None:
                 self._attach_playwright_listener(page, callback=callback)
         except Exception as exc:  # noqa: BLE001
-            spider.logger.warning("HtmlInspector skip: %s", exc)
+            logger.warning("HtmlInspector skip: %s", exc)
         return response
 
     # ------------------------------------------------------------------

--- a/src/moneyforward/middlewares/playwright_session.py
+++ b/src/moneyforward/middlewares/playwright_session.py
@@ -8,6 +8,7 @@ stale session and replays the login flow before retrying the original URL.
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from scrapy import Request
 from scrapy.exceptions import IgnoreRequest
@@ -20,21 +21,26 @@ logger = logging.getLogger(__name__)
 class PlaywrightSessionMiddleware:
     """Detect session expiry and retry up to ``login_max_retry`` times."""
 
+    crawler: Any  # set by from_crawler()
+
     def __init__(self, login_max_retry: int = 2) -> None:
         self.login_max_retry = login_max_retry
 
     @classmethod
     def from_crawler(cls, crawler):
-        return cls(
+        instance = cls(
             login_max_retry=crawler.settings.getint("MONEYFORWARD_LOGIN_MAX_RETRY", 2),
         )
+        instance.crawler = crawler
+        return instance
 
-    def process_response(self, request: Request, response, spider):
+    def process_response(self, request: Request, response):
         if not request.meta.get("playwright"):
             return response
         if not is_session_expired(response):
             return response
 
+        spider = self.crawler.spider
         attempts = int(request.meta.get("login_retry_times", 0))
         if attempts >= self.login_max_retry:
             spider.logger.error(

--- a/src/moneyforward/utils/logging_config.py
+++ b/src/moneyforward/utils/logging_config.py
@@ -110,7 +110,18 @@ def setup_common_logging(
     if ax is not None:
         root.addHandler(ax)
 
-    for noisy in ("urllib3", "asyncio", "playwright"):
+    for noisy in (
+        "urllib3",
+        "asyncio",
+        "playwright",
+        "scrapy.addons",
+        "scrapy.utils.log",
+        "scrapy.middleware",
+        "scrapy.core.engine",
+        "scrapy.crawler",
+        "scrapy.extensions.telnet",
+        "scrapy-playwright",
+    ):
         logging.getLogger(noisy).setLevel(logging.WARNING)
 
     # Sensitive-data redaction on each handler so all records — including those

--- a/tests/test_html_inspector_middleware_unit.py
+++ b/tests/test_html_inspector_middleware_unit.py
@@ -75,7 +75,7 @@ def test_extract_sub_path_rejects_traversal(url):
 def test_disabled_middleware_does_not_create_files(tmp_path):
     mw = HtmlInspectorMiddleware(output_dir=tmp_path / "inspect", enabled=False)
     resp = _response()
-    out = mw.process_response(Request(url=resp.url), resp, _spider())
+    out = mw.process_response(Request(url=resp.url), resp)
     assert out is resp
     assert not (tmp_path / "inspect").exists()
 
@@ -83,7 +83,7 @@ def test_disabled_middleware_does_not_create_files(tmp_path):
 def test_disabled_middleware_returns_same_response(tmp_path):
     mw = HtmlInspectorMiddleware(output_dir=tmp_path / "inspect", enabled=False)
     resp = _response()
-    assert mw.process_response(Request(url=resp.url), resp, _spider()) is resp
+    assert mw.process_response(Request(url=resp.url), resp) is resp
 
 
 # ------------------------------------------------------------------
@@ -109,7 +109,7 @@ def test_spider_opened_resets_seq(tmp_path):
     spider = _spider()
     mw.spider_opened(spider)
     resp = _response()
-    mw.process_response(Request(url=resp.url), resp, spider)
+    mw.process_response(Request(url=resp.url), resp)
     assert mw._seq == 1
     mw.spider_opened(spider)
     assert mw._seq == 0
@@ -124,9 +124,8 @@ def test_spider_closed_closes_flow_log(tmp_path):
 
 def test_process_response_before_spider_opened_is_noop(tmp_path):
     mw = HtmlInspectorMiddleware(output_dir=tmp_path / "inspect", enabled=True)
-    spider = _spider()
     resp = _response()
-    result = mw.process_response(Request(url=resp.url), resp, spider)
+    result = mw.process_response(Request(url=resp.url), resp)
     assert result is resp
     assert (
         not list((tmp_path / "inspect").rglob("*.html"))
@@ -143,7 +142,7 @@ def test_process_response_before_spider_opened_is_noop(tmp_path):
 def test_enabled_middleware_dumps_html(tmp_path):
     mw, spider = _enabled_mw(tmp_path)
     resp = _response(body=b"<html><body>secret-marker</body></html>")
-    mw.process_response(Request(url=resp.url), resp, spider)
+    mw.process_response(Request(url=resp.url), resp)
     files = list(mw.run_dir.rglob("*.html"))
     assert len(files) == 1
     assert "secret-marker" in files[0].read_text(encoding="utf-8")
@@ -152,7 +151,7 @@ def test_enabled_middleware_dumps_html(tmp_path):
 def test_url_path_maps_to_subdirectory(tmp_path):
     mw, spider = _enabled_mw(tmp_path)
     resp = _response(url="https://moneyforward.com/accounts/show")
-    mw.process_response(Request(url=resp.url), resp, spider)
+    mw.process_response(Request(url=resp.url), resp)
     expected_dir = mw.run_dir / "accounts"
     assert expected_dir.exists()
     assert len(list(expected_dir.glob("*.html"))) == 1
@@ -161,7 +160,7 @@ def test_url_path_maps_to_subdirectory(tmp_path):
 def test_error_status_gets_error_suffix(tmp_path):
     mw, spider = _enabled_mw(tmp_path)
     resp = _response(url="https://moneyforward.com/accounts/show", status=404)
-    mw.process_response(Request(url=resp.url), resp, spider)
+    mw.process_response(Request(url=resp.url), resp)
     files = list(mw.run_dir.rglob("*_error.html"))
     assert len(files) == 1
 
@@ -169,7 +168,7 @@ def test_error_status_gets_error_suffix(tmp_path):
 def test_ok_status_has_no_error_suffix(tmp_path):
     mw, spider = _enabled_mw(tmp_path)
     resp = _response(url="https://moneyforward.com/accounts/show", status=200)
-    mw.process_response(Request(url=resp.url), resp, spider)
+    mw.process_response(Request(url=resp.url), resp)
     files = list(mw.run_dir.rglob("*_error.html"))
     assert len(files) == 0
 
@@ -178,7 +177,7 @@ def test_enabled_middleware_writes_unique_filenames_per_response(tmp_path):
     mw, spider = _enabled_mw(tmp_path)
     for i in range(3):
         resp = _response(url=f"https://moneyforward.com/p/{i}", body=b"<html>x</html>")
-        mw.process_response(Request(url=resp.url), resp, spider)
+        mw.process_response(Request(url=resp.url), resp)
     files = list(mw.run_dir.rglob("*.html"))
     assert len(files) == 3
     assert len({f.name for f in files}) == 3
@@ -188,7 +187,7 @@ def test_same_url_twice_writes_two_files(tmp_path):
     mw, spider = _enabled_mw(tmp_path)
     for _ in range(2):
         resp = _response(url="https://moneyforward.com/accounts/show")
-        mw.process_response(Request(url=resp.url), resp, spider)
+        mw.process_response(Request(url=resp.url), resp)
     files = list(mw.run_dir.rglob("*.html"))
     assert len(files) == 2
 
@@ -196,7 +195,7 @@ def test_same_url_twice_writes_two_files(tmp_path):
 def test_enabled_middleware_handles_empty_body(tmp_path):
     mw, spider = _enabled_mw(tmp_path)
     resp = HtmlResponse(url="https://x/", body=b"", request=Request(url="https://x/"))
-    mw.process_response(Request(url=resp.url), resp, spider)
+    mw.process_response(Request(url=resp.url), resp)
     assert not list(mw.run_dir.rglob("*.html"))
 
 
@@ -208,7 +207,7 @@ def test_enabled_middleware_handles_empty_body(tmp_path):
 def test_flow_log_contains_entries(tmp_path):
     mw, spider = _enabled_mw(tmp_path)
     resp = _response(url="https://moneyforward.com/accounts/show")
-    mw.process_response(Request(url=resp.url), resp, spider)
+    mw.process_response(Request(url=resp.url), resp)
     lines = (mw.run_dir / "flow.log").read_text(encoding="utf-8").splitlines()
     assert len(lines) == 2  # meta + 1 entry
     entry = json.loads(lines[1])
@@ -220,7 +219,7 @@ def test_flow_log_contains_entries(tmp_path):
 def test_flow_log_error_entry(tmp_path):
     mw, spider = _enabled_mw(tmp_path)
     resp = _response(url="https://moneyforward.com/accounts/show", status=500)
-    mw.process_response(Request(url=resp.url), resp, spider)
+    mw.process_response(Request(url=resp.url), resp)
     lines = (mw.run_dir / "flow.log").read_text(encoding="utf-8").splitlines()
     entry = json.loads(lines[1])
     assert entry["error"] is True
@@ -229,7 +228,7 @@ def test_flow_log_error_entry(tmp_path):
 def test_flow_log_file_field_uses_forward_slash(tmp_path):
     mw, spider = _enabled_mw(tmp_path)
     resp = _response(url="https://moneyforward.com/accounts/show")
-    mw.process_response(Request(url=resp.url), resp, spider)
+    mw.process_response(Request(url=resp.url), resp)
     lines = (mw.run_dir / "flow.log").read_text(encoding="utf-8").splitlines()
     entry = json.loads(lines[1])
     assert "\\" not in entry["file"]
@@ -246,7 +245,7 @@ def test_playwright_listener_registered_once_per_page(tmp_path):
     for _ in range(3):
         req = Request(url="https://moneyforward.com/cf", meta={"playwright_page": page})
         resp = _response()
-        mw.process_response(req, resp, spider)
+        mw.process_response(req, resp)
     assert page.on.call_count == 1
     assert page.on.call_args == call("load", page.on.call_args[0][1])
 
@@ -257,7 +256,7 @@ def test_playwright_listener_different_pages_each_registered(tmp_path):
     for page in pages:
         req = Request(url="https://moneyforward.com/cf", meta={"playwright_page": page})
         resp = _response()
-        mw.process_response(req, resp, spider)
+        mw.process_response(req, resp)
     for page in pages:
         assert page.on.call_count == 1
 
@@ -268,7 +267,7 @@ def test_playwright_listener_callback_label(tmp_path):
     req = Request(url="https://moneyforward.com/cf", meta={"playwright_page": page})
     req.callback = MagicMock(__name__="parse_accounts")
     resp = _response()
-    mw.process_response(req, resp, spider)
+    mw.process_response(req, resp)
     assert page.on.called
     assert page.on.call_args[0][0] == "load"
 

--- a/tests/test_playwright_session_middleware_unit.py
+++ b/tests/test_playwright_session_middleware_unit.py
@@ -27,28 +27,37 @@ def _request(url="https://moneyforward.com/cf", attempts=0):
     return req
 
 
+def _mw(spider, login_max_retry: int = 2) -> PlaywrightSessionMiddleware:
+    mw = PlaywrightSessionMiddleware(login_max_retry=login_max_retry)
+    mw.crawler = MagicMock()
+    mw.crawler.spider = spider
+    return mw
+
+
 def test_passes_through_non_playwright_requests():
-    mw = PlaywrightSessionMiddleware(login_max_retry=2)
+    spider = _spider({})
+    mw = _mw(spider)
     req = Request(url="https://example.com/")
     resp = HtmlResponse(url=req.url, body=b"ok", request=req)
-    assert mw.process_response(req, resp, _spider({})) is resp
+    assert mw.process_response(req, resp) is resp
 
 
 def test_passes_through_healthy_response():
-    mw = PlaywrightSessionMiddleware(login_max_retry=2)
+    spider = _spider({})
+    mw = _mw(spider)
     req = _request()
     resp = HtmlResponse(
         url="https://moneyforward.com/cf",
         body="<html><head><title>家計簿</title></head></html>".encode("utf-8"),
         request=req,
     )
-    assert mw.process_response(req, resp, _spider({})) is resp
+    assert mw.process_response(req, resp) is resp
 
 
 def test_retries_on_login_url():
-    mw = PlaywrightSessionMiddleware(login_max_retry=2)
     stats: dict = {}
     spider = _spider(stats)
+    mw = _mw(spider)
     # Spider lacks handle_force_login → middleware returns the plain retry.
     spider.handle_force_login = None
     req = _request()
@@ -57,7 +66,7 @@ def test_retries_on_login_url():
         body="<html><head><title>ログイン</title></head></html>".encode("utf-8"),
         request=req,
     )
-    out = mw.process_response(req, resp, spider)
+    out = mw.process_response(req, resp)
     assert isinstance(out, Request)
     assert out.meta["login_retry_times"] == 1
     assert out.meta["moneyforward_force_login"] is True
@@ -66,7 +75,8 @@ def test_retries_on_login_url():
 
 def test_retry_drops_stale_playwright_page_meta():
     """Defect C2: request.copy() must not leak the closed page handle."""
-    mw = PlaywrightSessionMiddleware(login_max_retry=2)
+    spider = _spider({})
+    mw = _mw(spider)
     stale_page = MagicMock(name="closed_page")
     req = Request(
         url="https://moneyforward.com/cf",
@@ -82,9 +92,8 @@ def test_retry_drops_stale_playwright_page_meta():
         body=b"<html></html>",
         request=req,
     )
-    spider = _spider({})
     spider.handle_force_login = None
-    out = mw.process_response(req, resp, spider)
+    out = mw.process_response(req, resp)
     assert isinstance(out, Request)
     assert "playwright_page" not in out.meta
     assert "playwright_page_methods" not in out.meta
@@ -92,8 +101,8 @@ def test_retry_drops_stale_playwright_page_meta():
 
 def test_retry_invokes_handle_force_login():
     """Defect C1: middleware delegates to spider.handle_force_login when present."""
-    mw = PlaywrightSessionMiddleware(login_max_retry=2)
     spider = _spider({})
+    mw = _mw(spider)
     sentinel = Request(url="https://moneyforward.com/login")
     spider.handle_force_login = MagicMock(return_value=sentinel)
 
@@ -103,7 +112,7 @@ def test_retry_invokes_handle_force_login():
         body=b"<html></html>",
         request=req,
     )
-    out = mw.process_response(req, resp, spider)
+    out = mw.process_response(req, resp)
     assert out is sentinel
     spider.handle_force_login.assert_called_once()
     forwarded = spider.handle_force_login.call_args.args[0]
@@ -117,8 +126,9 @@ def test_stops_after_max_retry():
     invocation as ``failed: SessionExpired``."""
     from scrapy.exceptions import IgnoreRequest
 
-    mw = PlaywrightSessionMiddleware(login_max_retry=1)
     stats: dict = {}
+    spider = _spider(stats)
+    mw = _mw(spider, login_max_retry=1)
     req = _request(attempts=1)
     resp = HtmlResponse(
         url="https://moneyforward.com/sign_in",
@@ -126,7 +136,7 @@ def test_stops_after_max_retry():
         request=req,
     )
     with pytest.raises(IgnoreRequest):
-        mw.process_response(req, resp, _spider(stats))
+        mw.process_response(req, resp)
     assert stats["mf_test/session/expired_final"] == 1
 
 
@@ -141,9 +151,9 @@ def test_from_crawler_uses_settings_login_max_retry():
 
 def test_session_expiry_retry_invalidates_session_state():
     """Issue #43: middleware must drop on-disk storage_state before retry."""
-    mw = PlaywrightSessionMiddleware(login_max_retry=2)
     stats: dict = {}
     spider = _spider(stats)
+    mw = _mw(spider)
     spider.session_manager = MagicMock()
     spider.handle_force_login = MagicMock(side_effect=lambda r: r)
     req = _request(attempts=0)
@@ -154,7 +164,7 @@ def test_session_expiry_retry_invalidates_session_state():
         body=b"<html></html>",
         request=req,
     )
-    out = mw.process_response(req, resp, spider)
+    out = mw.process_response(req, resp)
     spider.session_manager.invalidate_session.assert_called_once()
     # The retry request must not carry the stale storage_state.
     assert isinstance(out, Request)
@@ -166,8 +176,8 @@ def test_retry_final_does_not_invoke_handle_force_login():
     instead it raises IgnoreRequest (Issue #40 / Opus M2)."""
     from scrapy.exceptions import IgnoreRequest
 
-    mw = PlaywrightSessionMiddleware(login_max_retry=1)
     spider = _spider({})
+    mw = _mw(spider, login_max_retry=1)
     spider.handle_force_login = MagicMock()
     req = _request(attempts=1)
     resp = HtmlResponse(
@@ -176,5 +186,5 @@ def test_retry_final_does_not_invoke_handle_force_login():
         request=req,
     )
     with pytest.raises(IgnoreRequest):
-        mw.process_response(req, resp, spider)
+        mw.process_response(req, resp)
     spider.handle_force_login.assert_not_called()


### PR DESCRIPTION
## Summary

- scrapy 系ログをサブロガー指定に変更（`scrapy.spiders` 等の有用ログは維持）
- `scrapy-playwright` / `scrapy.crawler` / `scrapy.addons` を抑制対象に追加
- `HtmlInspectorMiddleware` / `PlaywrightSessionMiddleware` の `process_response()` から `spider` 引数を除去し `ScrapyDeprecationWarning` を解消

## Test plan

- [ ] `pytest tests/test_playwright_session_middleware_unit.py tests/test_html_inspector_middleware_unit.py tests/test_logging_axiom_unit.py` — 65 passed 確認済み

closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)