### PR TITLE
feat: tools/dynamodb — 新設計対応テーブル初期設定ツール (#81)

### DIFF
--- a/tools/dynamodb/README.md
+++ b/tools/dynamodb/README.md
@@ -1,0 +1,57 @@
+# tools/dynamodb
+
+DynamoDB テーブル初期設定ツール。新 PJ の 3 テーブルを作成する。
+
+## 前提
+
+- Python 仮想環境 `.venv-win` がセットアップ済みであること
+- AWS 認証情報が設定済みであること（env var / `~/.aws/config` / IAM ロール）
+
+## 環境変数
+
+### テーブル名（作成対象を絞りたい場合は未設定のままにする）
+
+| 変数名 | 対応テーブル |
+|--------|-------------|
+| `DYNAMODB_TABLE_NAME_TRANSACTION` | 取引 |
+| `DYNAMODB_TABLE_NAME_ASSET_ALLOCATION` | 資産内訳 |
+| `DYNAMODB_TABLE_NAME_ACCOUNT` | 口座 |
+
+### AWS 認証情報
+
+| 変数名 | 説明 |
+|--------|------|
+| `AWS_DEFAULT_REGION` | リージョン（例: `ap-northeast-1`）|
+| `AWS_ACCESS_KEY_ID` | アクセスキー（未設定時は boto3 デフォルト連鎖）|
+| `AWS_SECRET_ACCESS_KEY` | シークレットキー（未設定時は boto3 デフォルト連鎖）|
+| `SECRETS_BACKEND` | `env`（デフォルト）または `bitwarden` |
+
+プロジェクトルートの `.env` を自動ロードする。
+
+## テーブル設計
+
+| テーブル種別 | PK (HASH) | SK (RANGE) | BillingMode |
+|-------------|-----------|------------|-------------|
+| transaction | `year_month` (S) | `data_table_sortable_value` (S) | PAY_PER_REQUEST |
+| asset_allocation | `year_month_day` (S) | `asset_item_key` (S) | PAY_PER_REQUEST |
+| account | `year_month_day` (S) | `account_item_key` (S) | PAY_PER_REQUEST |
+
+## 実行方法
+
+```bash
+# 内容確認（作成しない）
+.venv-win/Scripts/python.exe tools/dynamodb/setup_tables.py --dry-run
+
+# 実際に作成
+.venv-win/Scripts/python.exe tools/dynamodb/setup_tables.py
+```
+
+## 動作仕様
+
+- テーブル名 env var が未設定のテーブルはスキップ
+- 複数の env var に同じテーブル名が設定されている場合は起動時にエラーで中断
+- すでに存在するテーブルは `ResourceInUseException` をキャッチしてスキップ（べき等）
+  - 既存テーブルのキースキーマが想定と異なる場合は WARNING ログを出力
+- テーブル作成後は `wait_until_exists()` で ACTIVE 化を確認してから次へ進む
+- 個別テーブルの作成失敗は ERROR ログを出して次のテーブルを処理し、最後に `exit 1`
+- `--dry-run` では AWS への接続を行わず、作成予定内容をログ出力して終了

--- a/tools/dynamodb/setup_tables.py
+++ b/tools/dynamodb/setup_tables.py
@@ -1,0 +1,206 @@
+"""DynamoDB テーブル初期設定ツール.
+
+新 PJ の 3 テーブルを PAY_PER_REQUEST で作成する。
+テーブル名は環境変数から読み込み、未設定のテーブルはスキップ。
+既存テーブルは ResourceInUseException をキャッチしてスキップ（べき等）。
+既存テーブルのキースキーマが想定と異なる場合は WARNING ログを出す。
+テーブル名重複は事前に検知して中断する。
+
+環境変数:
+  DYNAMODB_TABLE_NAME_TRANSACTION
+  DYNAMODB_TABLE_NAME_ASSET_ALLOCATION
+  DYNAMODB_TABLE_NAME_ACCOUNT
+  AWS_DEFAULT_REGION        (任意; 未設定時は boto3 デフォルト)
+  AWS_ACCESS_KEY_ID         (任意; 未設定時は boto3 デフォルト連鎖)
+  AWS_SECRET_ACCESS_KEY     (任意; 未設定時は boto3 デフォルト連鎖)
+  SECRETS_BACKEND           (任意; "env" | "bitwarden", デフォルト "env")
+
+実行方法:
+  .venv-win/Scripts/python.exe tools/dynamodb/setup_tables.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+load_dotenv(_PROJECT_ROOT / ".env", override=False)
+
+_SRC_DIR = _PROJECT_ROOT / "src"
+if str(_SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(_SRC_DIR))
+
+from moneyforward.secrets import resolver as _secrets_resolver  # noqa: E402
+from moneyforward.secrets.exceptions import SecretNotFound  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+# pipelines/dynamodb.py の _PKEYS と同一設計（PK/SK 変更時は両方更新）。
+_TABLE_SCHEMA: dict[str, tuple[str, str]] = {
+    "transaction": ("year_month", "data_table_sortable_value"),
+    "asset_allocation": ("year_month_day", "asset_item_key"),
+    "account": ("year_month_day", "account_item_key"),
+}
+
+_TABLE_ENV_VARS: dict[str, str] = {
+    "transaction": "DYNAMODB_TABLE_NAME_TRANSACTION",
+    "asset_allocation": "DYNAMODB_TABLE_NAME_ASSET_ALLOCATION",
+    "account": "DYNAMODB_TABLE_NAME_ACCOUNT",
+}
+
+
+def _get_secret(key: str) -> str | None:
+    try:
+        return _secrets_resolver.get(key)
+    except SecretNotFound:
+        return None
+
+
+def _build_resource() -> Any:
+    import boto3  # type: ignore[import]
+
+    return boto3.resource(
+        "dynamodb",
+        aws_access_key_id=_get_secret("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=_get_secret("AWS_SECRET_ACCESS_KEY"),
+        region_name=os.environ.get("AWS_DEFAULT_REGION") or None,
+    )
+
+
+def _resolve_table_names() -> dict[str, str]:
+    return {
+        table_type: os.environ.get(env_var, "").strip()
+        for table_type, env_var in _TABLE_ENV_VARS.items()
+    }
+
+
+def _validate_unique(table_names: dict[str, str]) -> None:
+    seen: dict[str, str] = {}
+    for table_type, name in table_names.items():
+        if not name:
+            continue
+        if name in seen:
+            sys.exit(
+                f"エラー: テーブル名重複 — '{name}' が "
+                f"{seen[name]} と {table_type} の両方に設定されている"
+            )
+        seen[name] = table_type
+
+
+def _validate_existing_schema(
+    db: Any, table_name: str, expected_pk: str, expected_sk: str
+) -> None:
+    table = db.Table(table_name)
+    table.load()
+    actual = {k["KeyType"]: k["AttributeName"] for k in table.key_schema}
+    if actual.get("HASH") != expected_pk or actual.get("RANGE") != expected_sk:
+        logger.warning(
+            "スキーマ不一致: %s — 期待 (HASH=%s, RANGE=%s)  実際 (HASH=%s, RANGE=%s)",
+            table_name,
+            expected_pk,
+            expected_sk,
+            actual.get("HASH"),
+            actual.get("RANGE"),
+        )
+
+
+def _print_plan(table_names: dict[str, str]) -> None:
+    named = [n for n in table_names.values() if n]
+    width = max((len(n) for n in named), default=0)
+    logger.info("[DRY-RUN] 作成予定テーブル:")
+    for table_type, (pk, sk) in _TABLE_SCHEMA.items():
+        table_name = table_names[table_type]
+        env_var = _TABLE_ENV_VARS[table_type]
+        if not table_name:
+            logger.info("  SKIP   (%s 未設定)", env_var)
+        else:
+            logger.info("  CREATE %-*s  PK=%s  SK=%s", width, table_name, pk, sk)
+
+
+def _create_table(db: Any, table_name: str, pk: str, sk: str) -> str:
+    """テーブル作成。戻り値は "created" | "exists"。."""
+    from botocore.exceptions import ClientError  # type: ignore[import]
+
+    try:
+        table = db.create_table(
+            TableName=table_name,
+            AttributeDefinitions=[
+                {"AttributeName": pk, "AttributeType": "S"},
+                {"AttributeName": sk, "AttributeType": "S"},
+            ],
+            KeySchema=[
+                {"AttributeName": pk, "KeyType": "HASH"},
+                {"AttributeName": sk, "KeyType": "RANGE"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        table.wait_until_exists()
+        return "created"
+    except ClientError as err:
+        if err.response["Error"]["Code"] == "ResourceInUseException":
+            _validate_existing_schema(db, table_name, pk, sk)
+            return "exists"
+        raise
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    parser = argparse.ArgumentParser(description="DynamoDB テーブル初期設定")
+    parser.add_argument("--dry-run", action="store_true", help="作成せず内容確認のみ")
+    args = parser.parse_args()
+
+    table_names = _resolve_table_names()
+    _validate_unique(table_names)
+
+    if args.dry_run:
+        _print_plan(table_names)
+        logger.info("[DRY-RUN] 完了。変更なし。")
+        return
+
+    db = _build_resource()
+    created = exists = skipped = failed = 0
+
+    for table_type, (pk, sk) in _TABLE_SCHEMA.items():
+        table_name = table_names[table_type]
+        env_var = _TABLE_ENV_VARS[table_type]
+
+        if not table_name:
+            logger.info("skip (env unset): %s", env_var)
+            skipped += 1
+            continue
+
+        try:
+            result = _create_table(db, table_name, pk, sk)
+        except Exception as err:
+            logger.error("create_table failed: %s — %s", table_name, err)
+            failed += 1
+            continue
+
+        if result == "created":
+            logger.info("created: %s  (PK=%s, SK=%s)", table_name, pk, sk)
+            created += 1
+        else:
+            logger.info("exists (skip): %s", table_name)
+            exists += 1
+
+    logger.info(
+        "完了 — created=%d  exists=%d  skipped=%d  failed=%d",
+        created,
+        exists,
+        skipped,
+        failed,
+    )
+    if failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要

issue #81。旧 PJ の古い DynamoDB 初期設定ツールを廃止し、新 PJ の 3 テーブル設計に対応した初期設定ツールを `tools/dynamodb/` に整備。

## 成果物

- `tools/dynamodb/setup_tables.py` — テーブル作成スクリプト
- `tools/dynamodb/README.md` — 使い方ドキュメント

## テーブル設計

| テーブル種別 | PK (HASH) | SK (RANGE) |
|-------------|-----------|------------|
| transaction | `year_month` | `data_table_sortable_value` |
| asset_allocation | `year_month_day` | `asset_item_key` |
| account | `year_month_day` | `account_item_key` |

## 主な実装ポイント

- **べき等**: 既存テーブルは `ResourceInUseException` をキャッチしてスキップ
- **スキーマ検証**: 既存テーブルの PK/SK が想定と異なれば WARNING ログ
- **重複検知**: 複数 env var に同一テーブル名が設定されていたら起動時エラーで中断
- **非同期対応**: `table.wait_until_exists()` で ACTIVE 化を確認してから次へ
- **エラー継続**: 個別テーブル失敗は ERROR ログ → 残りを処理 → 最後に `exit 1`
- **`--dry-run`**: AWS 接続なしで作成予定内容をログ出力
- **BillingMode**: `PAY_PER_REQUEST`（旧 PJ から変更）
- **認証**: env var / Bitwarden / boto3 デフォルト連鎖に対応

## 関連資料

- issue: #81
- plan: plan/20260506_tools_dynamodb_setup.md（未作成のため本 PR が仕様）

🤖 Generated with [Claude Code](https://claude.com/claude-code)